### PR TITLE
Add octree rendering with hard-coded data

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -1,5 +1,6 @@
 #include "editor.h"
-#include "vxng/scene.h"
+
+#include "vxng/vxng.h"
 
 #include <SDL3/SDL.h>
 #include <sdl3webgpu.h>

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -1,4 +1,5 @@
 #include "editor.h"
+#include "vxng/scene.h"
 
 #include <SDL3/SDL.h>
 #include <sdl3webgpu.h>
@@ -149,6 +150,11 @@ Editor::~Editor() {
 }
 
 auto Editor::run() -> void {
+    auto scene = vxng::scene::Scene();
+    scene.init_webgpu(this->wgpu.device);
+
+    this->renderer.set_scene(&scene);
+
     bool quit = false;
     while (!quit) {
         poll_events(quit);

--- a/editor/src/editor.h
+++ b/editor/src/editor.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "vxng/orbit-camera.h"
-#include "vxng/renderer.h"
+#include "vxng/vxng.h"
 
 #include <SDL3/SDL.h>
 #include <webgpu/webgpu_cpp.h>

--- a/libs/vxng/CMakeLists.txt
+++ b/libs/vxng/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(${PROJECT_NAME}
     src/wgsl/fullscreen.wgsl.cpp
     src/camera/camera.cpp
     src/camera/orbit-camera.cpp
+    src/scene/chunk.cpp
     src/scene/scene.cpp
     src/renderer.cpp
 )

--- a/libs/vxng/include/vxng/renderer.h
+++ b/libs/vxng/include/vxng/renderer.h
@@ -38,6 +38,7 @@ class Renderer {
     } wgpu;
 
     const vxng::camera::Camera *active_camera;
+    const vxng::scene::Scene *active_scene;
 };
 
 } // namespace vxng

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -19,6 +19,9 @@ class Scene {
 
     auto init_webgpu(wgpu::Device device) -> void;
 
+    auto get_chunks() const
+        -> const std::unordered_map<glm::ivec3, std::unique_ptr<Chunk>> &;
+
   private:
     std::unordered_map<glm::ivec3, std::unique_ptr<Chunk>> chunks;
 };

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -1,11 +1,26 @@
 #pragma once
 
+#include <glm/glm.hpp>
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/hash.hpp>
+#include <webgpu/webgpu_cpp.h>
+
+#include <memory>
+#include <unordered_map>
+
 namespace vxng::scene {
+
+class Chunk;
 
 class Scene {
   public:
     Scene();
     ~Scene();
+
+    auto init_webgpu(wgpu::Device device) -> void;
+
+  private:
+    std::unordered_map<glm::ivec3, std::unique_ptr<Chunk>> chunks;
 };
 
 } // namespace vxng::scene

--- a/libs/vxng/include/vxng/vxng.h
+++ b/libs/vxng/include/vxng/vxng.h
@@ -2,5 +2,7 @@
 
 // This primary file exports all public headers
 
-#include "renderer.h" // IWYU pragma: export
-#include "scene.h"    // IWYU pragma: export
+#include "camera.h"       // IWYU pragma: export
+#include "orbit-camera.h" // IWYU pragma: export
+#include "renderer.h"     // IWYU pragma: export
+#include "scene.h"        // IWYU pragma: export

--- a/libs/vxng/src/camera/orbit-camera.cpp
+++ b/libs/vxng/src/camera/orbit-camera.cpp
@@ -13,19 +13,19 @@ OrbitCamera::OrbitCamera(glm::vec3 target, glm::vec3 angle_euler_yxz,
 }
 
 OrbitCamera::OrbitCamera()
-    : OrbitCamera(glm::vec3(0), glm::vec3(0.7f, 0.5f, 0.f), 8.f, 0.7f) {};
+    : OrbitCamera(glm::vec3(0), glm::vec3(-0.5f, 0.5f, 0.f), 8.f, 0.7f) {};
 
 OrbitCamera::~OrbitCamera() = default;
 
 auto OrbitCamera::handle_rotation(float dx, float dy) -> void {
     // clamp x rotation to not go upside down
-    this->angle_euler.x += dy * this->settings.rotate_sensitivity;
+    this->angle_euler.x += -dy * this->settings.rotate_sensitivity;
     this->angle_euler.x = glm::clamp(this->angle_euler.x, this->settings.min_x,
                                      this->settings.max_x);
 
     // wrap y rotation to prevent accumulation issues
     this->angle_euler.y =
-        glm::mod(this->angle_euler.y + dx * this->settings.rotate_sensitivity,
+        glm::mod(this->angle_euler.y + -dx * this->settings.rotate_sensitivity,
                  glm::two_pi<float>());
 
     this->update_camera();
@@ -43,7 +43,7 @@ auto OrbitCamera::handle_pan(float dx, float dy) -> void {
     glm::vec3 right = this->rotation[0];
     glm::vec3 up = this->rotation[1];
 
-    this->target += (right * dx + up * dy) * this->settings.pan_sensitivity;
+    this->target += (right * -dx + up * dy) * this->settings.pan_sensitivity;
 
     this->update_camera();
     this->update_webgpu();

--- a/libs/vxng/src/renderer.cpp
+++ b/libs/vxng/src/renderer.cpp
@@ -43,6 +43,8 @@ auto Renderer::init_webgpu(wgpu::Device device) -> bool {
     // create bind group layouts for shaders
     wgpu::BindGroupLayout globals_bind_group_layout = nullptr;
     wgpu::BindGroupLayout camera_bind_group_layout = nullptr;
+    wgpu::BindGroupLayout chunk_bind_group_layout =
+        scene::Chunk::get_bindgroup_layout(device);
     {
         // globals bind group layout (group 0)
         wgpu::BindGroupLayoutEntry globals_layout_entry;
@@ -110,12 +112,13 @@ auto Renderer::init_webgpu(wgpu::Device device) -> bool {
     // create pipeline layout
     wgpu::PipelineLayout pipeline_layout = nullptr;
     {
-        std::array<wgpu::BindGroupLayout, 2> bind_group_layouts = {
-            globals_bind_group_layout, camera_bind_group_layout};
+        std::array<wgpu::BindGroupLayout, 3> bind_group_layouts = {
+            globals_bind_group_layout, camera_bind_group_layout,
+            chunk_bind_group_layout};
 
         wgpu::PipelineLayoutDescriptor layout_desc;
         layout_desc.label = "Render pipeline layout";
-        layout_desc.bindGroupLayoutCount = 2;
+        layout_desc.bindGroupLayoutCount = bind_group_layouts.size();
         layout_desc.bindGroupLayouts = bind_group_layouts.data();
         pipeline_layout = device.CreatePipelineLayout(&layout_desc);
     }

--- a/libs/vxng/src/renderer.cpp
+++ b/libs/vxng/src/renderer.cpp
@@ -1,6 +1,6 @@
 #include "vxng/renderer.h"
 
-#include "util.h"
+#include "scene/chunk.h"
 #include "wgsl/shaders.h"
 
 #include <array>
@@ -231,8 +231,12 @@ auto Renderer::render(wgpu::RenderPassEncoder &render_pass) const -> void {
     render_pass.SetBindGroup(0, this->wgpu.globals_bind_group);
     render_pass.SetBindGroup(1, this->wgpu.camera_bind_group);
 
-    // draw fullscreen triangle (3 vertices, 1 instance)
-    render_pass.Draw(3, 1, 0, 0);
+    for (auto &[coord, chunk] : this->active_scene->get_chunks()) {
+        render_pass.SetBindGroup(2, chunk->get_bindgroup());
+
+        // draw fullscreen triangle (3 vertices, 1 instance)
+        render_pass.Draw(3, 1, 0, 0);
+    }
 };
 
 } // namespace vxng

--- a/libs/vxng/src/renderer.cpp
+++ b/libs/vxng/src/renderer.cpp
@@ -203,7 +203,7 @@ auto Renderer::resize(int width, int height) -> void {
 };
 
 auto Renderer::set_scene(const vxng::scene::Scene *scene) -> void {
-    throw not_implemented_error();
+    this->active_scene = scene;
 };
 
 auto Renderer::set_active_camera(const vxng::camera::Camera *camera) -> void {

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -1,0 +1,88 @@
+#include "chunk.h"
+
+#include <vector>
+
+namespace vxng::scene {
+
+Chunk::Chunk(glm::vec3 pos, float scale, int resolution)
+    : position(pos), scale(scale), resolution(resolution) {};
+Chunk::~Chunk() {
+    if (!this->wgpu.initialized)
+        return;
+
+    this->wgpu.octree_ssbo.Destroy();
+    this->wgpu.vxdata_ssbo.Destroy();
+};
+
+auto Chunk::init_webgpu(wgpu::Device device) -> void {
+    wgpu::Buffer octree_ssbo;
+    {
+        wgpu::BufferDescriptor desc;
+        desc.label = "Octree nodes storage buffer";
+        desc.size = sizeof(uint32_t) * 3; // one GPUOctreeNode for now
+        desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+        octree_ssbo = device.CreateBuffer(&desc);
+    }
+
+    wgpu::Buffer vxdata_ssbo;
+    {
+        wgpu::BufferDescriptor desc;
+        desc.label = "Voxel data storage buffer";
+        desc.size = sizeof(uint32_t); // one GPUVoxelData for now
+        desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+        vxdata_ssbo = device.CreateBuffer(&desc);
+    }
+
+    this->wgpu.initialized = true;
+    this->wgpu.device = device;
+    this->wgpu.octree_ssbo = octree_ssbo;
+    this->wgpu.vxdata_ssbo = vxdata_ssbo;
+
+    update_buffers();
+}
+
+auto Chunk::get_octree_buffer() const -> wgpu::Buffer {
+    return this->wgpu.octree_ssbo.Get();
+}
+
+auto Chunk::get_voxel_data_buffer() const -> wgpu::Buffer {
+    return this->wgpu.vxdata_ssbo.Get();
+}
+
+typedef struct GPUOctreeNode {
+    uint32_t child_mask;      // leaf node if this is empty
+    uint32_t first_child_idx; // we can find subsequent child indices
+                              // (contiguous) using bitCount(child_mask)
+    uint32_t voxel_data_idx;
+} GPUOctreeNode;
+
+typedef struct GPUVoxelData {
+    uint32_t color_packed;
+} GPUVoxelData;
+
+auto Chunk::update_buffers() -> void {
+    std::vector<GPUOctreeNode> octree_nodes;
+    std::vector<GPUVoxelData> voxel_datas;
+
+    // TODO: implement buffer computation from structure
+    // for now: just render one solid cube
+    GPUOctreeNode root;
+    root.child_mask = 0;
+    root.first_child_idx = 0;
+    root.voxel_data_idx = 0;
+    octree_nodes.push_back(root);
+
+    GPUVoxelData root_data;
+    root_data.color_packed =
+        (255u << 0) | (0u << 8) | (0u << 16) | (255u << 24); // RGBA red
+    voxel_datas.push_back(root_data);
+
+    wgpu::Queue queue = this->wgpu.device.GetQueue();
+
+    queue.WriteBuffer(this->wgpu.octree_ssbo, 0, octree_nodes.data(),
+                      sizeof(GPUOctreeNode) * octree_nodes.size());
+    queue.WriteBuffer(this->wgpu.vxdata_ssbo, 0, voxel_datas.data(),
+                      sizeof(GPUVoxelData) * voxel_datas.size());
+}
+
+} // namespace vxng::scene

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -1,8 +1,13 @@
 #include "chunk.h"
+#include "webgpu/webgpu_cpp.h"
 
 #include <vector>
 
 namespace vxng::scene {
+
+// static stuffs
+wgpu::BindGroupLayout Chunk::bindgroup_layout = nullptr;
+bool Chunk::bindgroup_layout_created = false;
 
 Chunk::Chunk(glm::vec3 pos, float scale, int resolution)
     : position(pos), scale(scale), resolution(resolution) {};
@@ -10,43 +15,93 @@ Chunk::~Chunk() {
     if (!this->wgpu.initialized)
         return;
 
-    this->wgpu.octree_ssbo.Destroy();
-    this->wgpu.vxdata_ssbo.Destroy();
+    this->wgpu.octree_buffer.Destroy();
+    this->wgpu.vxdata_buffer.Destroy();
 };
 
 auto Chunk::init_webgpu(wgpu::Device device) -> void {
-    wgpu::Buffer octree_ssbo;
+    wgpu::Buffer octree_buffer;
     {
         wgpu::BufferDescriptor desc;
         desc.label = "Octree nodes storage buffer";
         desc.size = sizeof(uint32_t) * 3; // one GPUOctreeNode for now
         desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
-        octree_ssbo = device.CreateBuffer(&desc);
+        octree_buffer = device.CreateBuffer(&desc);
     }
 
-    wgpu::Buffer vxdata_ssbo;
+    wgpu::Buffer vxdata_buffer;
     {
         wgpu::BufferDescriptor desc;
         desc.label = "Voxel data storage buffer";
         desc.size = sizeof(uint32_t); // one GPUVoxelData for now
         desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
-        vxdata_ssbo = device.CreateBuffer(&desc);
+        vxdata_buffer = device.CreateBuffer(&desc);
+    }
+
+    // run static BGL setup (only once)
+    if (!Chunk::bindgroup_layout_created)
+        Chunk::create_bindgroup_layout(device);
+
+    wgpu::BindGroup bindgroup;
+    {
+        wgpu::BindGroupEntry entries[2];
+
+        auto &octree_entry = entries[0];
+        octree_entry.binding = 0;
+        octree_entry.buffer = octree_buffer;
+        octree_entry.offset = 0;
+        octree_entry.size = sizeof(uint32_t) * 3;
+
+        auto &vxdata_entry = entries[1];
+        vxdata_entry.binding = 1;
+        vxdata_entry.buffer = vxdata_buffer;
+        vxdata_entry.offset = 0;
+        vxdata_entry.size = sizeof(uint32_t);
+
+        wgpu::BindGroupDescriptor bg_desc;
+        bg_desc.label = "Chunk data bind group";
+        bg_desc.layout = bindgroup_layout;
+        bg_desc.entryCount = 2;
+        bg_desc.entries = &entries[0];
+        bindgroup = device.CreateBindGroup(&bg_desc);
     }
 
     this->wgpu.initialized = true;
     this->wgpu.device = device;
-    this->wgpu.octree_ssbo = octree_ssbo;
-    this->wgpu.vxdata_ssbo = vxdata_ssbo;
+    this->wgpu.octree_buffer = octree_buffer;
+    this->wgpu.vxdata_buffer = vxdata_buffer;
+    this->wgpu.bindgroup = bindgroup;
 
+    // get starting data to the gpu!
     update_buffers();
 }
 
-auto Chunk::get_octree_buffer() const -> wgpu::Buffer {
-    return this->wgpu.octree_ssbo.Get();
+auto Chunk::get_bindgroup() const -> wgpu::BindGroup {
+    return this->wgpu.bindgroup;
 }
 
-auto Chunk::get_voxel_data_buffer() const -> wgpu::Buffer {
-    return this->wgpu.vxdata_ssbo.Get();
+auto Chunk::create_bindgroup_layout(wgpu::Device device) -> void {
+    wgpu::BindGroupLayoutEntry bgl_entries[2];
+
+    auto &octree_entry = bgl_entries[0];
+    octree_entry.binding = 0;
+    octree_entry.visibility = wgpu::ShaderStage::Fragment;
+    octree_entry.buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
+    octree_entry.buffer.minBindingSize = sizeof(uint32_t) * 3;
+
+    auto &vxdata_entry = bgl_entries[1];
+    vxdata_entry.binding = 1;
+    vxdata_entry.visibility = wgpu::ShaderStage::Fragment;
+    vxdata_entry.buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
+    vxdata_entry.buffer.minBindingSize = sizeof(uint32_t);
+
+    wgpu::BindGroupLayoutDescriptor bgl_descriptor = {};
+    bgl_descriptor.label = "Chunk data bind group layout";
+    bgl_descriptor.entryCount = 2;
+    bgl_descriptor.entries = &bgl_entries[0];
+
+    bindgroup_layout = device.CreateBindGroupLayout(&bgl_descriptor);
+    bindgroup_layout_created = true;
 }
 
 typedef struct GPUOctreeNode {
@@ -74,14 +129,14 @@ auto Chunk::update_buffers() -> void {
 
     GPUVoxelData root_data;
     root_data.color_packed =
-        (255u << 0) | (0u << 8) | (0u << 16) | (255u << 24); // RGBA red
+        (255u << 0) | (0u << 8) | (255u << 16) | (255u << 24); // RGBA magenta
     voxel_datas.push_back(root_data);
 
     wgpu::Queue queue = this->wgpu.device.GetQueue();
 
-    queue.WriteBuffer(this->wgpu.octree_ssbo, 0, octree_nodes.data(),
+    queue.WriteBuffer(this->wgpu.octree_buffer, 0, octree_nodes.data(),
                       sizeof(GPUOctreeNode) * octree_nodes.size());
-    queue.WriteBuffer(this->wgpu.vxdata_ssbo, 0, voxel_datas.data(),
+    queue.WriteBuffer(this->wgpu.vxdata_buffer, 0, voxel_datas.data(),
                       sizeof(GPUVoxelData) * voxel_datas.size());
 }
 

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -64,10 +64,6 @@ auto Chunk::init_webgpu(wgpu::Device device) -> void {
         metadata_buffer = device.CreateBuffer(&desc);
     }
 
-    // run static BGL setup (only once)
-    if (!Chunk::bindgroup_layout_created)
-        Chunk::create_bindgroup_layout(device);
-
     wgpu::BindGroup bindgroup;
     {
         wgpu::BindGroupEntry entries[3];
@@ -92,7 +88,7 @@ auto Chunk::init_webgpu(wgpu::Device device) -> void {
 
         wgpu::BindGroupDescriptor bg_desc;
         bg_desc.label = "Chunk data bind group";
-        bg_desc.layout = bindgroup_layout;
+        bg_desc.layout = get_bindgroup_layout(device);
         bg_desc.entryCount = 3;
         bg_desc.entries = &entries[0];
         bindgroup = device.CreateBindGroup(&bg_desc);
@@ -140,7 +136,15 @@ auto Chunk::create_bindgroup_layout(wgpu::Device device) -> void {
     bgl_descriptor.entries = &bgl_entries[0];
 
     bindgroup_layout = device.CreateBindGroupLayout(&bgl_descriptor);
-    bindgroup_layout_created = true;
+}
+
+auto Chunk::get_bindgroup_layout(wgpu::Device device) -> wgpu::BindGroupLayout {
+    if (!bindgroup_layout_created) {
+        create_bindgroup_layout(device);
+        bindgroup_layout_created = true;
+    }
+
+    return bindgroup_layout;
 }
 
 auto Chunk::update_buffers() -> void {

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -14,10 +14,14 @@ class Chunk {
     ~Chunk();
 
     auto init_webgpu(wgpu::Device device) -> void;
-    auto get_octree_buffer() const -> wgpu::Buffer;
-    auto get_voxel_data_buffer() const -> wgpu::Buffer;
+    auto get_bindgroup() const -> wgpu::BindGroup;
 
   private:
+    static wgpu::BindGroupLayout bindgroup_layout; // shared bindgroup layout
+    static bool bindgroup_layout_created;
+    /** should only run this once using `bindgroup_layout_created` */
+    static auto create_bindgroup_layout(wgpu::Device device) -> void;
+
     auto update_buffers() -> void;
 
     typedef struct VoxelData {
@@ -42,8 +46,9 @@ class Chunk {
     struct {
         bool initialized;
         wgpu::Device device;
-        wgpu::Buffer octree_ssbo;
-        wgpu::Buffer vxdata_ssbo;
+        wgpu::Buffer octree_buffer;
+        wgpu::Buffer vxdata_buffer;
+        wgpu::BindGroup bindgroup;
     } wgpu;
 };
 

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <webgpu/webgpu_cpp.h>
+
+#include <array>
+#include <memory>
+
+namespace vxng::scene {
+
+class Chunk {
+  public:
+    Chunk(glm::vec3 pos, float scale, int resolution);
+    ~Chunk();
+
+    auto init_webgpu(wgpu::Device device) -> void;
+    auto get_octree_buffer() const -> wgpu::Buffer;
+    auto get_voxel_data_buffer() const -> wgpu::Buffer;
+
+  private:
+    auto update_buffers() -> void;
+
+    typedef struct VoxelData {
+        glm::u8vec4 color; // so much memory eek
+    } VoxelData;
+
+    typedef struct OctreeNode {
+        bool is_leaf;
+
+        bool leaf_is_solid;
+        VoxelData leaf_data;
+
+        std::array<std::unique_ptr<OctreeNode>, 8> children;
+    } OctreeNode;
+
+    glm::vec3 position;
+    float scale;
+    int resolution;
+
+    std::unique_ptr<OctreeNode> root_node;
+
+    struct {
+        bool initialized;
+        wgpu::Device device;
+        wgpu::Buffer octree_ssbo;
+        wgpu::Buffer vxdata_ssbo;
+    } wgpu;
+};
+
+} // namespace vxng::scene

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -48,6 +48,7 @@ class Chunk {
         wgpu::Device device;
         wgpu::Buffer octree_buffer;
         wgpu::Buffer vxdata_buffer;
+        wgpu::Buffer metadata_buffer;
         wgpu::BindGroup bindgroup;
     } wgpu;
 };

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -16,6 +16,10 @@ class Chunk {
     auto init_webgpu(wgpu::Device device) -> void;
     auto get_bindgroup() const -> wgpu::BindGroup;
 
+    /** runs create_bindgroup_layout if not bindgroup_layout_created */
+    static auto get_bindgroup_layout(wgpu::Device device)
+        -> wgpu::BindGroupLayout;
+
   private:
     static wgpu::BindGroupLayout bindgroup_layout; // shared bindgroup layout
     static bool bindgroup_layout_created;

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -1,8 +1,19 @@
 #include "vxng/scene.h"
 
+#include "chunk.h"
+
+#include <memory>
+
 namespace vxng::scene {
 
 Scene::Scene() {}
 Scene::~Scene() {}
+
+auto Scene::init_webgpu(wgpu::Device device) -> void {
+    auto origin_chunk = std::make_unique<Chunk>(glm::vec3(0), 4.0, 512);
+    origin_chunk->init_webgpu(device);
+
+    this->chunks[glm::ivec3(0)] = std::move(origin_chunk);
+}
 
 } // namespace vxng::scene

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -16,4 +16,9 @@ auto Scene::init_webgpu(wgpu::Device device) -> void {
     this->chunks[glm::ivec3(0)] = std::move(origin_chunk);
 }
 
+auto Scene::get_chunks() const
+    -> const std::unordered_map<glm::ivec3, std::unique_ptr<Chunk>> & {
+    return this->chunks;
+}
+
 } // namespace vxng::scene

--- a/libs/vxng/src/wgsl/fullscreen.wgsl.cpp
+++ b/libs/vxng/src/wgsl/fullscreen.wgsl.cpp
@@ -62,6 +62,9 @@ fn raycastAABB(ray: Ray, aabb: AABB) -> f32 {
 
 @group(0) @binding(0) var<uniform> globals: Globals;
 @group(1) @binding(0) var<uniform> camera: Camera;
+// TODO: we gotta pass these guys in!
+// @group(2) @binding(0) var<storage, read> octreeNodes: array<OctreeNode>;
+// @group(2) @binding(1) var<storage, read> voxelData: array<VoxelData>;
 
 // Vertex shader output / Fragment shader input
 struct VertexOutput {

--- a/libs/vxng/src/wgsl/fullscreen.wgsl.cpp
+++ b/libs/vxng/src/wgsl/fullscreen.wgsl.cpp
@@ -15,6 +15,51 @@ struct Camera {
     fovYRad: f32,
 }
 
+struct OctreeNode {
+    childMask: u32,
+    firstChildIdx: u32,
+    voxelDataIdx: u32,
+}
+
+struct VoxelData {
+    colorPacked: u32,
+}
+
+struct Ray {
+    origin: vec3<f32>,
+    direction: vec3<f32>,
+}
+
+struct AABB {
+    bounds_min: vec3<f32>,
+    bounds_max: vec3<f32>,
+}
+
+// from https://github.com/gdbooks/3DCollisions/blob/master/Chapter3/raycast_aabb.md
+// spits out t = distance along ray a collision was found, or -1 if none
+fn raycastAABB(ray: Ray, aabb: AABB) -> f32 {
+    let t1 = (aabb.bounds_min.x - ray.origin.x) / ray.direction.x;
+    let t2 = (aabb.bounds_max.x - ray.origin.x) / ray.direction.x;
+    let t3 = (aabb.bounds_min.y - ray.origin.y) / ray.direction.y;
+    let t4 = (aabb.bounds_max.y - ray.origin.y) / ray.direction.y;
+    let t5 = (aabb.bounds_min.z - ray.origin.z) / ray.direction.z;
+    let t6 = (aabb.bounds_max.z - ray.origin.z) / ray.direction.z;
+    let tmin = max(max(min(t1, t2), min(t3, t4)), min(t5, t6));
+    let tmax = min(min(max(t1, t2), max(t3, t4)), max(t5, t6));
+    // if tmax < 0, ray (line) is intersecting AABB, but whole AABB is behind us
+    if (tmax < 0.0) {
+        return -1.0;
+    }
+    // if tmin > tmax, ray doesn't intersect AABB
+    if (tmin > tmax) {
+        return -1.0;
+    }
+    if (tmin < 0.0) {
+        return tmax;
+    }
+    return tmin;
+}
+
 @group(0) @binding(0) var<uniform> globals: Globals;
 @group(1) @binding(0) var<uniform> camera: Camera;
 

--- a/libs/vxng/src/wgsl/fullscreen.wgsl.cpp
+++ b/libs/vxng/src/wgsl/fullscreen.wgsl.cpp
@@ -117,17 +117,25 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     viewRay.direction = invViewMat3 * rayDirView;
     viewRay.origin = camera.invViewMat[3].xyz;
 
-    // TODO: traverse octree instead of just getting root
-    // let rootNode = octreeNodes[0];
-    var testAABB: AABB;
-    testAABB.bounds_min = vec3<f32>(-1.0);
-    testAABB.bounds_max = vec3<f32>(1.0);
-    let t = raycastAABB(viewRay, testAABB);
+    // just raycast against root node
+    let rootNode = octreeNodes[0];
+    let halfSize = chunkMetadata.size * 0.5;
+    var rootAABB: AABB;
+    rootAABB.bounds_min = chunkMetadata.position - vec3<f32>(halfSize);
+    rootAABB.bounds_max = chunkMetadata.position + vec3<f32>(halfSize);
+
+    let t = raycastAABB(viewRay, rootAABB);
     if (t < 0.0) {
         return vec4<f32>(viewRay.direction, 1.0);
-    } else {
-        return vec4<f32>(1.0, 0.0, 0.0, 1.0);
     }
+
+    // i love unpacking color!
+    let packed = voxelData[rootNode.voxelDataIdx].colorPacked;
+    let r = f32(packed & 0xFFu) / 255.0;
+    let g = f32((packed >> 8u) & 0xFFu) / 255.0;
+    let b = f32((packed >> 16u) & 0xFFu) / 255.0;
+    let a = f32((packed >> 24u) & 0xFFu) / 255.0;
+    return vec4<f32>(r, g, b, a);
 }
 )wgsl";
 

--- a/libs/vxng/src/wgsl/fullscreen.wgsl.cpp
+++ b/libs/vxng/src/wgsl/fullscreen.wgsl.cpp
@@ -98,16 +98,27 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         -1.0
     ));
 
-    // Transform to world space
+    // Build view ray
     let invViewMat3 = mat3x3<f32>(
         camera.invViewMat[0].xyz,
         camera.invViewMat[1].xyz,
         camera.invViewMat[2].xyz
     );
-    let rayDirWorld = invViewMat3 * rayDirView;
-    let rayOrigin = camera.invViewMat[3].xyz;
+    var viewRay: Ray;
+    viewRay.direction = invViewMat3 * rayDirView;
+    viewRay.origin = camera.invViewMat[3].xyz;
 
-    return vec4<f32>(rayDirWorld, 1.0);
+    // TODO: traverse octree instead of just getting root
+    // let rootNode = octreeNodes[0];
+    var testAABB: AABB;
+    testAABB.bounds_min = vec3<f32>(-1.0);
+    testAABB.bounds_max = vec3<f32>(1.0);
+    let t = raycastAABB(viewRay, testAABB);
+    if (t < 0.0) {
+        return vec4<f32>(viewRay.direction, 1.0);
+    } else {
+        return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+    }
 }
 )wgsl";
 

--- a/libs/vxng/src/wgsl/fullscreen.wgsl.cpp
+++ b/libs/vxng/src/wgsl/fullscreen.wgsl.cpp
@@ -25,6 +25,11 @@ struct VoxelData {
     colorPacked: u32,
 }
 
+struct ChunkMetadata {
+    position: vec3<f32>,
+    size: f32,
+}
+
 struct Ray {
     origin: vec3<f32>,
     direction: vec3<f32>,
@@ -63,8 +68,9 @@ fn raycastAABB(ray: Ray, aabb: AABB) -> f32 {
 @group(0) @binding(0) var<uniform> globals: Globals;
 @group(1) @binding(0) var<uniform> camera: Camera;
 // TODO: we gotta pass these guys in!
-// @group(2) @binding(0) var<storage, read> octreeNodes: array<OctreeNode>;
-// @group(2) @binding(1) var<storage, read> voxelData: array<VoxelData>;
+@group(2) @binding(0) var<storage, read> octreeNodes: array<OctreeNode>;
+@group(2) @binding(1) var<storage, read> voxelData: array<VoxelData>;
+@group(2) @binding(2) var<uniform> chunkMetadata: ChunkMetadata;
 
 // Vertex shader output / Fragment shader input
 struct VertexOutput {


### PR DESCRIPTION
This PR will add octree data structures on both the CPU and GPU side, and configure the fullscreen shader to render whatever octree it is fed. All this information is kept in a binding group per chunk, with the future intent to render multiple chunks in a row.

Currently the CPU side does not automatically generate the GPU struct data, but instead sends over a simple hard-coded octree with a single green and single magenta leaf voxel.

- Add octree node/data structs on CPU and GPU side
  - CPU side: uses smart pointers, recursive data structure, voxel data (color) inside same structs
  - GPU side: big arrays, one for octree nodes, one for voxel data (pointed to by leaf nodes). octree children are notated using bitmask and stored contiguously.
- Add Chunk data structure, which manages its own binding group containing all important voxel data
  - An unordered map of these lives in the Scene object
- Implement stack-based (DFS) raycast octree traversal in fullscreen shader
- patch: updates orbit camera controls