### PR TITLE
Add octree + voxeldata buffer building logic

### DIFF
--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -1,5 +1,6 @@
 #include "chunk.h"
-#include "webgpu/webgpu_cpp.h"
+
+#include <webgpu/webgpu_cpp.h>
 
 #include <memory>
 #include <queue>

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -14,10 +14,7 @@ typedef struct VoxelData {
 
 typedef struct OctreeNode {
     bool is_leaf;
-
-    bool leaf_is_solid;
     VoxelData leaf_data;
-
     std::array<std::unique_ptr<OctreeNode>, 8> children;
 } OctreeNode;
 

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -8,6 +8,35 @@
 
 namespace vxng::scene {
 
+typedef struct VoxelData {
+    glm::u8vec4 color; // so much memory eek
+} VoxelData;
+
+typedef struct OctreeNode {
+    bool is_leaf;
+
+    bool leaf_is_solid;
+    VoxelData leaf_data;
+
+    std::array<std::unique_ptr<OctreeNode>, 8> children;
+} OctreeNode;
+
+typedef struct GPUOctreeNode {
+    uint32_t child_mask;      // leaf node if this is empty
+    uint32_t first_child_idx; // we can find subsequent child indices
+                              // (contiguous) using bitCount(child_mask)
+    uint32_t voxel_data_idx;
+} GPUOctreeNode;
+
+typedef struct GPUVoxelData {
+    uint32_t color_packed;
+} GPUVoxelData;
+
+typedef struct GPUChunkMetadata {
+    float position[3];
+    float size;
+} GPUChunkMetadata;
+
 class Chunk {
   public:
     Chunk(glm::vec3 pos, float scale, int resolution);
@@ -27,19 +56,9 @@ class Chunk {
     static auto create_bindgroup_layout(wgpu::Device device) -> void;
 
     auto update_buffers() -> void;
-
-    typedef struct VoxelData {
-        glm::u8vec4 color; // so much memory eek
-    } VoxelData;
-
-    typedef struct OctreeNode {
-        bool is_leaf;
-
-        bool leaf_is_solid;
-        VoxelData leaf_data;
-
-        std::array<std::unique_ptr<OctreeNode>, 8> children;
-    } OctreeNode;
+    auto build_buffer_data(std::vector<GPUOctreeNode> *octree_nodes,
+                           std::vector<GPUVoxelData> *voxel_datas) const
+        -> void;
 
     glm::vec3 position;
     float scale;


### PR DESCRIPTION
This PR will introduce GPU buffer generation logic for chunks. It does a BFS through CPU-side nodes and spits out flat GPU-ready arrays with index pointers.

<img width="628" height="541" alt="image" src="https://github.com/user-attachments/assets/52b1ceda-accd-46fa-9126-02d0eed7723d" />

- Add private `build_buffer_data` method to chunks
  - Turns CPU voxel data into GPU buffers, pushed into `octree_nodes` and `voxel_datas` arrays (by pointer)
- Move hardcoded voxel data into chunk constructor
- patch: move private struct definitions to header file
- chore: cleanup include formatting