### PR TITLE
Implement live voxel updates

### DIFF
--- a/editor/src/editor.h
+++ b/editor/src/editor.h
@@ -24,6 +24,7 @@ class Editor {
 
     vxng::Renderer renderer;
     vxng::camera::OrbitCamera viewport_camera;
+    vxng::scene::Scene scene;
 
     auto draw_to_surface() -> void;
     auto get_next_surface_texture_view() -> wgpu::TextureView;
@@ -32,5 +33,6 @@ class Editor {
 
     auto poll_events(bool &quit) -> void;
     auto handle_resize(int width, int height) -> void;
+    auto handle_key_down(SDL_KeyboardEvent event, bool *quit) -> void;
     auto handle_mouse_motion(SDL_MouseMotionEvent event) -> void;
 };

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -28,6 +28,10 @@ class Scene {
 
   private:
     std::unordered_map<glm::ivec3, std::unique_ptr<Chunk>> chunks;
+
+    struct {
+        wgpu::Device device;
+    } wgpu;
 };
 
 } // namespace vxng::scene

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -19,6 +19,10 @@ class Scene {
 
     auto init_webgpu(wgpu::Device device) -> void;
 
+    auto set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color)
+        -> void;
+
+    /** Internal method, for renderer to render chunks */
     auto get_chunks() const
         -> const std::unordered_map<glm::ivec3, std::unique_ptr<Chunk>> &;
 

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "glm/fwd.hpp"
 #include <glm/glm.hpp>
 #include <webgpu/webgpu_cpp.h>
 
@@ -40,7 +41,11 @@ class Chunk {
     ~Chunk();
 
     auto init_webgpu(wgpu::Device device) -> void;
+    /** For rendering: we can hook up bindgroup to render this chunk */
     auto get_bindgroup() const -> wgpu::BindGroup;
+
+    auto set_voxel_filled(int depth, glm::vec3 local_position,
+                          glm::u8vec4 color) -> void;
 
     /** runs create_bindgroup_layout if not bindgroup_layout_created */
     static auto get_bindgroup_layout(wgpu::Device device)

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -12,7 +12,13 @@ namespace vxng::scene {
 Scene::Scene() {}
 Scene::~Scene() {}
 
-auto Scene::init_webgpu(wgpu::Device device) -> void {}
+auto Scene::init_webgpu(wgpu::Device device) -> void {
+    auto origin_chunk = std::make_unique<Chunk>(glm::vec3(0), 4.0, 512);
+    origin_chunk->init_webgpu(device);
+
+    this->chunks[glm::ivec3(0)] = std::move(origin_chunk);
+    this->wgpu.device = device;
+}
 
 auto Scene::get_chunks() const
     -> const std::unordered_map<glm::ivec3, std::unique_ptr<Chunk>> & {
@@ -29,6 +35,7 @@ auto Scene::set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color)
     if (!this->chunks[chunk_coord]) {
         this->chunks[chunk_coord] = std::make_unique<Chunk>(
             chunk_origin, CHUNK_SCALE, CHUNK_RESOLUTION);
+        this->chunks[chunk_coord]->init_webgpu(this->wgpu.device);
     }
 
     this->chunks[chunk_coord]->set_voxel_filled(depth, local_position, color);

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -4,7 +4,7 @@
 
 #include <memory>
 
-#define CHUNK_SCALE 4.0
+#define CHUNK_SCALE 4.0f
 #define CHUNK_RESOLUTION 512
 
 namespace vxng::scene {
@@ -12,17 +12,26 @@ namespace vxng::scene {
 Scene::Scene() {}
 Scene::~Scene() {}
 
-auto Scene::init_webgpu(wgpu::Device device) -> void {
-    auto origin_chunk =
-        std::make_unique<Chunk>(glm::vec3(0), CHUNK_SCALE, CHUNK_RESOLUTION);
-    origin_chunk->init_webgpu(device);
-
-    this->chunks[glm::ivec3(0)] = std::move(origin_chunk);
-}
+auto Scene::init_webgpu(wgpu::Device device) -> void {}
 
 auto Scene::get_chunks() const
     -> const std::unordered_map<glm::ivec3, std::unique_ptr<Chunk>> & {
     return this->chunks;
+}
+
+auto Scene::set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color)
+    -> void {
+    glm::ivec3 chunk_coord =
+        glm::floor((position + glm::vec3(CHUNK_SCALE * 0.5f)) / CHUNK_SCALE);
+    glm::vec3 chunk_origin = (glm::vec3(chunk_coord) * CHUNK_SCALE);
+    glm::vec3 local_position = (position - chunk_origin) / CHUNK_SCALE;
+
+    if (!this->chunks[chunk_coord]) {
+        this->chunks[chunk_coord] = std::make_unique<Chunk>(
+            chunk_origin, CHUNK_SCALE, CHUNK_RESOLUTION);
+    }
+
+    this->chunks[chunk_coord]->set_voxel_filled(depth, local_position, color);
 }
 
 } // namespace vxng::scene

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -4,13 +4,17 @@
 
 #include <memory>
 
+#define CHUNK_SCALE 4.0
+#define CHUNK_RESOLUTION 512
+
 namespace vxng::scene {
 
 Scene::Scene() {}
 Scene::~Scene() {}
 
 auto Scene::init_webgpu(wgpu::Device device) -> void {
-    auto origin_chunk = std::make_unique<Chunk>(glm::vec3(0), 4.0, 512);
+    auto origin_chunk =
+        std::make_unique<Chunk>(glm::vec3(0), CHUNK_SCALE, CHUNK_RESOLUTION);
     origin_chunk->init_webgpu(device);
 
     this->chunks[glm::ivec3(0)] = std::move(origin_chunk);


### PR DESCRIPTION
This PR will implement the ability to press A to add a voxel at a random depth with a random color.

<img width="612" height="572" alt="image" src="https://github.com/user-attachments/assets/bf76a379-9227-4336-bfe3-c1150418a01e" />


- Add `set_voxel_filled` method to `Scene` and `Chunk`
  - Makes new chunks if coordinate is outside existing chunks
  - Called with random-ish parameters upon pressing "A" on keyboard
- patch: move `scene` to a member variable in `Editor`
- patch: move button handling to independent method in `Editor`

We still need:
- Octree relaxation
- Multi-chunk rendering with a depth buffer