### PR TITLE
Render multiple chunks

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -185,9 +185,18 @@ auto Editor::draw_to_surface() -> void {
     renderPassColorAttachment.storeOp = wgpu::StoreOp::Store;
     renderPassColorAttachment.clearValue = wgpu::Color{0.0, 0.0, 0.0, 1.0};
 
+    // depth attachment for multi-chunk rendering
+    wgpu::RenderPassDepthStencilAttachment depthAttachment;
+    depthAttachment.view = renderer.get_depth_texture_view();
+    depthAttachment.depthLoadOp = wgpu::LoadOp::Clear;
+    depthAttachment.depthStoreOp = wgpu::StoreOp::Store;
+    depthAttachment.depthClearValue = 1.0f; // far plane
+    depthAttachment.stencilLoadOp = wgpu::LoadOp::Undefined;
+    depthAttachment.stencilStoreOp = wgpu::StoreOp::Undefined;
+
     renderPassDesc.colorAttachmentCount = 1;
     renderPassDesc.colorAttachments = &renderPassColorAttachment;
-    renderPassDesc.depthStencilAttachment = nullptr;
+    renderPassDesc.depthStencilAttachment = &depthAttachment;
     renderPassDesc.timestampWrites = nullptr;
 
     // render pass!

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -316,8 +316,8 @@ auto Editor::handle_key_down(SDL_KeyboardEvent event, bool *quit) -> void {
         auto rand_pos =
             (glm::vec3(random_float(), random_float(), random_float()) -
              glm::vec3(0.5f)) *
-            3.99f;
-        auto rand_depth = rand() % 5 + 4;
+            11.99f;
+        auto rand_depth = rand() % 7 + 2;
         auto rand_color =
             glm::u8vec4(rand() % 256, rand() % 256, rand() % 256, 255);
         this->scene.set_voxel_filled(rand_depth, rand_pos, rand_color);

--- a/libs/vxng/CMakeLists.txt
+++ b/libs/vxng/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(vxng)
 
 add_library(${PROJECT_NAME}
-    src/wgsl/fullscreen.wgsl.cpp
+    src/wgsl/chunk.wgsl.cpp
     src/camera/camera.cpp
     src/camera/orbit-camera.cpp
     src/scene/chunk.cpp

--- a/libs/vxng/include/vxng/renderer.h
+++ b/libs/vxng/include/vxng/renderer.h
@@ -17,12 +17,15 @@ class Renderer {
 
     /** Sets up program + shader bindings */
     auto init_webgpu(wgpu::Device device) -> bool;
+    auto get_depth_texture_view() const -> wgpu::TextureView;
     auto resize(int width, int height) -> void;
     auto set_scene(vxng::scene::Scene const *scene) -> void;
     auto set_active_camera(const vxng::camera::Camera *camera) -> void;
     auto render(wgpu::RenderPassEncoder &render_pass) const -> void;
 
   private:
+    auto create_depth_texture(int width, int height) -> void;
+
     struct {
         bool initialized;
         wgpu::Device device;
@@ -35,6 +38,8 @@ class Renderer {
         wgpu::ShaderModule shader_module;
         wgpu::PipelineLayout pipeline_layout;
         wgpu::RenderPipeline render_pipeline;
+        wgpu::Texture depth_texture;
+        wgpu::TextureView depth_texture_view;
     } wgpu;
 
     const vxng::camera::Camera *active_camera;

--- a/libs/vxng/src/renderer.cpp
+++ b/libs/vxng/src/renderer.cpp
@@ -49,7 +49,8 @@ auto Renderer::init_webgpu(wgpu::Device device) -> bool {
         // globals bind group layout (group 0)
         wgpu::BindGroupLayoutEntry globals_layout_entry;
         globals_layout_entry.binding = 0;
-        globals_layout_entry.visibility = wgpu::ShaderStage::Fragment;
+        globals_layout_entry.visibility =
+            wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
         globals_layout_entry.buffer.type = wgpu::BufferBindingType::Uniform;
         globals_layout_entry.buffer.minBindingSize = 4;
 
@@ -63,7 +64,8 @@ auto Renderer::init_webgpu(wgpu::Device device) -> bool {
         // camera bind group layout (group 1)
         wgpu::BindGroupLayoutEntry camera_layout_entry;
         camera_layout_entry.binding = 0;
-        camera_layout_entry.visibility = wgpu::ShaderStage::Fragment;
+        camera_layout_entry.visibility =
+            wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
         camera_layout_entry.buffer.type = wgpu::BufferBindingType::Uniform;
         camera_layout_entry.buffer.minBindingSize = 144;
 
@@ -243,8 +245,8 @@ auto Renderer::render(wgpu::RenderPassEncoder &render_pass) const -> void {
     for (auto &[coord, chunk] : this->active_scene->get_chunks()) {
         render_pass.SetBindGroup(2, chunk->get_bindgroup());
 
-        // draw fullscreen triangle (3 vertices, 1 instance)
-        render_pass.Draw(3, 1, 0, 0);
+        // draw chunk AABB cube (36 vertices = 12 triangles)
+        render_pass.Draw(36, 1, 0, 0);
     }
 };
 

--- a/libs/vxng/src/renderer.cpp
+++ b/libs/vxng/src/renderer.cpp
@@ -98,7 +98,7 @@ auto Renderer::init_webgpu(wgpu::Device device) -> bool {
     wgpu::ShaderModule shader_module = nullptr;
     {
         wgpu::ShaderSourceWGSL wgsl_source;
-        wgsl_source.code = vxng::shaders::FULLSCREEN_WGSL.c_str();
+        wgsl_source.code = vxng::shaders::CHUNK_WGSL.c_str();
 
         wgpu::ShaderModuleDescriptor shader_desc;
         shader_desc.nextInChain = &wgsl_source;

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -103,9 +103,9 @@ auto Chunk::create_bindgroup_layout(wgpu::Device device) -> void {
 
     auto &metadata_entry = bgl_entries[2];
     metadata_entry.binding = 2;
-    metadata_entry.visibility = wgpu::ShaderStage::Fragment;
+    metadata_entry.visibility =
+        wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
     metadata_entry.buffer.type = wgpu::BufferBindingType::Uniform;
-    metadata_entry.buffer.minBindingSize = sizeof(GPUChunkMetadata);
 
     wgpu::BindGroupLayoutDescriptor bgl_descriptor = {};
     bgl_descriptor.label = "Chunk data bind group layout";

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -13,22 +13,7 @@ wgpu::BindGroupLayout Chunk::bindgroup_layout = nullptr;
 bool Chunk::bindgroup_layout_created = false;
 
 Chunk::Chunk(glm::vec3 pos, float scale, int resolution)
-    : position(pos), scale(scale), resolution(resolution) {
-    // TEMP: setup hardcoded scene
-    this->root_node = std::make_unique<OctreeNode>();
-    auto &root = this->root_node;
-
-    root->is_leaf = false;
-    root->children[0] = std::make_unique<OctreeNode>();
-    root->children[7] = std::make_unique<OctreeNode>();
-    auto &leaf1 = root->children[0];
-    auto &leaf2 = root->children[7];
-
-    leaf1->is_leaf = true;
-    leaf1->leaf_data.color = {200, 100, 0, 255};
-    leaf2->is_leaf = true;
-    leaf2->leaf_data.color = {0, 100, 200, 255};
-};
+    : position(pos), scale(scale), resolution(resolution) {};
 
 Chunk::~Chunk() {
     if (!this->wgpu.initialized)

--- a/libs/vxng/src/wgsl/chunk.wgsl.cpp
+++ b/libs/vxng/src/wgsl/chunk.wgsl.cpp
@@ -2,7 +2,7 @@
 
 namespace vxng::shaders {
 
-const std::string FULLSCREEN_WGSL = R"wgsl(
+const std::string CHUNK_WGSL = R"wgsl(
 // Uniform buffer for global settings
 struct Globals {
     aspectRatio: f32,

--- a/libs/vxng/src/wgsl/fullscreen.wgsl.cpp
+++ b/libs/vxng/src/wgsl/fullscreen.wgsl.cpp
@@ -272,7 +272,7 @@ fn traverseOctree(ray: Ray, rootAABB: AABB) -> TraversalResult {
 // Vertex shader output / Fragment shader input
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) texcoords: vec2<f32>,
+    @location(0) worldPos: vec3<f32>,
 }
 
 struct FragmentOutput {
@@ -293,42 +293,62 @@ fn computeDepth(ray: Ray, t: f32) -> f32 {
         (linearZ * (FAR_PLANE - NEAR_PLANE));
 }
 
+// Unit cube geometry: 8 corners from [-0.5, 0.5]
+const CUBE_POSITIONS = array<vec3<f32>, 8>(
+    vec3<f32>(-0.5, -0.5, -0.5), // 0: left  bottom back
+    vec3<f32>( 0.5, -0.5, -0.5), // 1: right bottom back
+    vec3<f32>( 0.5,  0.5, -0.5), // 2: right top    back
+    vec3<f32>(-0.5,  0.5, -0.5), // 3: left  top    back
+    vec3<f32>(-0.5, -0.5,  0.5), // 4: left  bottom front
+    vec3<f32>( 0.5, -0.5,  0.5), // 5: right bottom front
+    vec3<f32>( 0.5,  0.5,  0.5), // 6: right top    front
+    vec3<f32>(-0.5,  0.5,  0.5), // 7: left  top    front
+);
+
+// 12 triangles (36 indices), CCW winding from outside
+const CUBE_INDICES = array<u32, 36>(
+    0u, 2u, 1u,  0u, 3u, 2u,  // back  (-Z)
+    4u, 5u, 6u,  4u, 6u, 7u,  // front (+Z)
+    0u, 4u, 7u,  0u, 7u, 3u,  // left  (-X)
+    1u, 2u, 6u,  1u, 6u, 5u,  // right (+X)
+    0u, 1u, 5u,  0u, 5u, 4u,  // bottom(-Y)
+    3u, 7u, 6u,  3u, 6u, 2u,  // top   (+Y)
+);
+
 @vertex
 fn vs_main(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
-    // Fullscreen triangle vertices
-    var vertices = array<vec2<f32>, 3>(
-        vec2<f32>(-1.0, -1.0),
-        vec2<f32>(3.0, -1.0),
-        vec2<f32>(-1.0, 3.0)
+    let cubePos = CUBE_POSITIONS[CUBE_INDICES[vertexIndex]];
+
+    // Transform unit cube [-0.5, 0.5]^3 to chunk world space
+    let worldPos = cubePos * chunkMetadata.size + chunkMetadata.position;
+
+    // View transform
+    let viewPos = camera.viewMat * vec4<f32>(worldPos, 1.0);
+
+    // Build perspective projection from fov and aspect ratio
+    // WebGPU clip space: x,y in [-1,1], z in [0,1]
+    let f = 1.0 / tan(camera.fovYRad * 0.5);
+    let nf = NEAR_PLANE - FAR_PLANE;
+    let clipPos = vec4<f32>(
+        viewPos.x * f / globals.aspectRatio,
+        viewPos.y * f,
+        viewPos.z * FAR_PLANE / nf + NEAR_PLANE * FAR_PLANE / nf,
+        -viewPos.z
     );
 
     var output: VertexOutput;
-    output.position = vec4<f32>(vertices[vertexIndex], 0.0, 1.0);
-    output.texcoords = 0.5 * output.position.xy + vec2<f32>(0.5);
+    output.position = clipPos;
+    output.worldPos = worldPos;
     return output;
 }
 
 @fragment
 fn fs_main(input: VertexOutput) -> FragmentOutput {
-    let ndcCoords = input.texcoords * 2.0 - 1.0;
-
-    // Compute ray direction in view space
-    let tanHalfFov = tan(camera.fovYRad * 0.5);
-    let rayDirView = normalize(vec3<f32>(
-        ndcCoords.x * globals.aspectRatio * tanHalfFov,
-        ndcCoords.y * tanHalfFov,
-        -1.0
-    ));
-
-    // Build view ray
-    let invViewMat3 = mat3x3<f32>(
-        camera.invViewMat[0].xyz,
-        camera.invViewMat[1].xyz,
-        camera.invViewMat[2].xyz
-    );
+    // Build ray from camera through this fragment's world position
+    let cameraPos = camera.invViewMat[3].xyz;
     var viewRay: Ray;
-    viewRay.direction = invViewMat3 * rayDirView;
-    viewRay.origin = camera.invViewMat[3].xyz;
+    viewRay.origin = cameraPos;
+    viewRay.direction = normalize(input.worldPos - cameraPos);
 
     // setup root AABB from chunk metadata
     let halfSize = chunkMetadata.size * 0.5;
@@ -341,9 +361,9 @@ fn fs_main(input: VertexOutput) -> FragmentOutput {
 
     var output: FragmentOutput;
     if (result.color.a == 0.0) {
-        // if no hit, show ray direction as sky with max depth
-        output.color = vec4<f32>(viewRay.direction, 1.0);
-        output.depth = 0.9999999; // slightly less than 1.0 to pass depth test
+        // no voxel hit within this chunk's AABB — discard so the
+        // clear color / sky pass shows through
+        discard;
     } else {
         // simple half lambert lighting
         let lightDir = normalize(vec3<f32>(0.5, 1.0, 0.3));

--- a/libs/vxng/src/wgsl/shaders.h
+++ b/libs/vxng/src/wgsl/shaders.h
@@ -4,6 +4,6 @@
 
 namespace vxng::shaders {
 
-extern const std::string FULLSCREEN_WGSL;
+extern const std::string CHUNK_WGSL;
 
 } // namespace vxng::shaders


### PR DESCRIPTION
This PR will introduce multi-chunk rendering. At first this was just going to be a fullscreen shader pass modification, but the performance wasn't ideal so instead it also reworks the chunk rendering to use cubes representing the chunk bounds.

(video added in post)

https://github.com/user-attachments/assets/59383169-4e43-44b8-b256-bfda26c0e847

- `Renderer` now creates a depth texture which gets exposed publicly for `Editor`
  - `Editor` hooks depth texture into render pass
- Chunk rendering now sets frag depth data or discards if nothing was hit
- optimization: chunks are now rendered using transformed boxes instead of fullscreen to prevent overdraw
- patch: remove default placeholder chunk data
- patch: rename `fullscreen.wgsl.cpp` to `chunk.wgsl.cpp` for accuracy