### PR TITLE
Add scene scale slider, cleanup headers

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -12,7 +12,7 @@
 #include <cstdlib>
 #include <iostream>
 
-Editor::Editor() : renderer(), viewport_camera(), scene() {};
+Editor::Editor() : renderer(), viewport_camera(), scene(512, 32.f) {};
 
 auto Editor::init() -> int {
 
@@ -201,6 +201,36 @@ auto Editor::run() -> void {
 }
 
 auto Editor::draw_to_surface() -> void {
+
+    // render UI
+    ImGui_ImplWGPU_NewFrame();
+    ImGui_ImplSDL3_NewFrame();
+    ImGui::NewFrame();
+
+    // show basic text
+    ImGui::Begin("Options");
+    if (ImGui::CollapsingHeader("Scene", ImGuiTreeNodeFlags_DefaultOpen |
+                                             ImGuiTreeNodeFlags_Framed)) {
+
+        // Scene Resolution
+        float scale = this->scene.get_chunk_scale();
+        int unit_voxel_depth = glm::log2(512.f / scale);
+        int original_uvd = unit_voxel_depth;
+        ImGui::SliderInt("Resolution", &unit_voxel_depth, 1, 5);
+        ImGui::TextWrapped("This is measured in \"unit voxel depth\", i.e. how "
+                           "many depths of octrees inhabit one unit of space.");
+        if (unit_voxel_depth != original_uvd) {
+            // snap scale to powers of 2
+            float new_scale = 512.f / glm::pow(2.f, unit_voxel_depth);
+            this->scene.set_chunk_scale(new_scale);
+        }
+    }
+
+    ImGui::End();
+
+    // render imgui
+    ImGui::Render();
+
     // Get the next target texture view
     wgpu::TextureView targetView = get_next_surface_texture_view();
     if (!targetView)
@@ -245,18 +275,6 @@ auto Editor::draw_to_surface() -> void {
     // delegate this to our vxng::Renderer
     renderer.render(renderPass);
 
-    // setup imgui
-    ImGui_ImplWGPU_NewFrame();
-    ImGui_ImplSDL3_NewFrame();
-    ImGui::NewFrame();
-
-    // show basic text
-    ImGui::Begin("Hello, ImGui!");
-    ImGui::Text("This is a basic imgui window");
-    ImGui::End();
-
-    // render imgui
-    ImGui::Render();
     ImGui_ImplWGPU_RenderDrawData(ImGui::GetDrawData(), renderPass.Get());
 
     renderPass.End();
@@ -379,8 +397,8 @@ auto Editor::handle_key_down(SDL_KeyboardEvent event, bool *quit) -> void {
         auto rand_pos =
             (glm::vec3(random_float(), random_float(), random_float()) -
              glm::vec3(0.5f)) *
-            11.99f;
-        auto rand_depth = rand() % 7 + 2;
+            0.99f * this->scene.get_chunk_scale();
+        auto rand_depth = rand() % 5 + 4;
         auto rand_color =
             glm::u8vec4(rand() % 256, rand() % 256, rand() % 256, 255);
         this->scene.set_voxel_filled(rand_depth, rand_pos, rand_color);

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -16,20 +16,34 @@ class Chunk;
 
 class Scene {
   public:
+    Scene(int chunk_resolution, float chunk_scale);
     Scene();
     ~Scene();
 
     auto init_webgpu(wgpu::Device device) -> void;
 
+    // --------- Queries / Mutation ---------
+
     auto raycast(const geometry::Ray &ray) const -> geometry::RaycastResult;
+
     auto set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color)
         -> void;
+
+    // --------- Utility ---------
+
+    auto get_chunk_scale() const -> float;
+    auto get_chunk_resolution() const -> int;
+    auto set_chunk_scale(float new_scale) -> void;
+
+    // --------- Rendering ---------
 
     /** Internal method, for renderer to render chunks */
     auto get_chunks() const
         -> const std::unordered_map<glm::ivec3, std::unique_ptr<Chunk>> &;
 
   private:
+    float chunk_scale;
+    int chunk_resolution;
     std::unordered_map<glm::ivec3, std::unique_ptr<Chunk>> chunks;
 
     struct {

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -179,6 +179,13 @@ auto Chunk::set_voxel_filled(int depth, glm::vec3 local_position,
     update_buffers();
 };
 
+auto Chunk::reposition(glm::vec3 pos, float scale) -> void {
+    this->position = pos;
+    this->scale = scale;
+
+    update_buffers();
+}
+
 auto Chunk::create_bindgroup_layout(wgpu::Device device) -> void {
     wgpu::BindGroupLayoutEntry bgl_entries[3];
 

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -41,15 +41,27 @@ class Chunk {
     Chunk(glm::vec3 pos, float scale, int resolution);
     ~Chunk();
 
-    auto init_webgpu(wgpu::Device device) -> void;
-    /** For rendering: we can hook up bindgroup to render this chunk */
-    auto get_bindgroup() const -> wgpu::BindGroup;
+    // --------- Lifecycle ---------
 
-    auto get_bounds() const -> geometry::AABB;
+    auto init_webgpu(wgpu::Device device) -> void;
+
+    // --------- Querying ---------
+
     auto raycast(const geometry::Ray &ray) const -> geometry::RaycastResult;
+
+    // --------- Mutation ---------
 
     auto set_voxel_filled(int depth, glm::vec3 local_position,
                           glm::u8vec4 color) -> void;
+
+    // --------- Utility ---------
+
+    auto get_bounds() const -> geometry::AABB;
+
+    // --------- Rendering ---------
+
+    /** For rendering: we can hook up bindgroup to render this chunk */
+    auto get_bindgroup() const -> wgpu::BindGroup;
 
     /** runs create_bindgroup_layout if not bindgroup_layout_created */
     static auto get_bindgroup_layout(wgpu::Device device)

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -58,6 +58,9 @@ class Chunk {
 
     auto get_bounds() const -> geometry::AABB;
 
+    /** Sets new position and scale, then updates buffers */
+    auto reposition(glm::vec3 pos, float scale) -> void;
+
     // --------- Rendering ---------
 
     /** For rendering: we can hook up bindgroup to render this chunk */

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -88,6 +88,10 @@ auto Scene::set_chunk_scale(float new_scale) -> void {
     this->chunk_scale = new_scale;
 
     for (const auto &chunk_pair : this->chunks) {
+        glm::ivec3 chunk_ipos = chunk_pair.first;
+        glm::vec3 chunk_pos = glm::vec3(chunk_ipos) * new_scale;
+
+        chunk_pair.second->reposition(chunk_pos, new_scale);
     }
 }
 

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -3,13 +3,28 @@
 #include "chunk.h"
 
 #include <memory>
+#include <stdexcept>
 
-#define CHUNK_SCALE 4.0f
-#define CHUNK_RESOLUTION 512
+#define DEFAULT_CHUNK_SCALE 4.0f
+#define DEFAULT_CHUNK_RESOLUTION 512
 
 namespace vxng::scene {
 
-Scene::Scene() {}
+Scene::Scene(int chunk_resolution, float chunk_scale)
+    : chunk_resolution(chunk_resolution), chunk_scale(chunk_scale) {
+    if (chunk_resolution <= 0 ||
+        (chunk_resolution & (chunk_resolution - 1)) == 0) {
+        throw std::invalid_argument("Chunk resolution must be a power of 2");
+    }
+
+    if (chunk_scale <= 0) {
+        throw std::invalid_argument("Chunk scale must be greater than 0");
+    }
+}
+Scene::Scene()
+    : chunk_resolution(DEFAULT_CHUNK_RESOLUTION),
+      chunk_scale(DEFAULT_CHUNK_SCALE) {}
+
 Scene::~Scene() {}
 
 auto Scene::init_webgpu(wgpu::Device device) -> void {
@@ -49,18 +64,31 @@ auto Scene::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
 
 auto Scene::set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color)
     -> void {
-    glm::ivec3 chunk_coord =
-        glm::floor((position + glm::vec3(CHUNK_SCALE * 0.5f)) / CHUNK_SCALE);
-    glm::vec3 chunk_origin = (glm::vec3(chunk_coord) * CHUNK_SCALE);
-    glm::vec3 local_position = (position - chunk_origin) / CHUNK_SCALE;
+    glm::ivec3 chunk_coord = glm::floor(
+        (position + glm::vec3(this->chunk_scale * 0.5f)) / this->chunk_scale);
+    glm::vec3 chunk_origin = (glm::vec3(chunk_coord) * this->chunk_scale);
+    glm::vec3 local_position = (position - chunk_origin) / this->chunk_scale;
 
     if (!this->chunks[chunk_coord]) {
         this->chunks[chunk_coord] = std::make_unique<Chunk>(
-            chunk_origin, CHUNK_SCALE, CHUNK_RESOLUTION);
+            chunk_origin, this->chunk_scale, this->chunk_resolution);
         this->chunks[chunk_coord]->init_webgpu(this->wgpu.device);
     }
 
     this->chunks[chunk_coord]->set_voxel_filled(depth, local_position, color);
+}
+
+auto Scene::get_chunk_scale() const -> float { return this->chunk_scale; }
+
+auto Scene::get_chunk_resolution() const -> int {
+    return this->chunk_resolution;
+}
+
+auto Scene::set_chunk_scale(float new_scale) -> void {
+    this->chunk_scale = new_scale;
+
+    for (const auto &chunk_pair : this->chunks) {
+    }
 }
 
 } // namespace vxng::scene

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -13,7 +13,7 @@ namespace vxng::scene {
 Scene::Scene(int chunk_resolution, float chunk_scale)
     : chunk_resolution(chunk_resolution), chunk_scale(chunk_scale) {
     if (chunk_resolution <= 0 ||
-        (chunk_resolution & (chunk_resolution - 1)) == 0) {
+        !((chunk_resolution & (chunk_resolution - 1)) == 0)) {
         throw std::invalid_argument("Chunk resolution must be a power of 2");
     }
 
@@ -21,6 +21,7 @@ Scene::Scene(int chunk_resolution, float chunk_scale)
         throw std::invalid_argument("Chunk scale must be greater than 0");
     }
 }
+
 Scene::Scene()
     : chunk_resolution(DEFAULT_CHUNK_RESOLUTION),
       chunk_scale(DEFAULT_CHUNK_SCALE) {}

--- a/libs/vxng/src/wgsl/chunk.wgsl.cpp
+++ b/libs/vxng/src/wgsl/chunk.wgsl.cpp
@@ -282,7 +282,7 @@ struct FragmentOutput {
 
 // for depth mapping
 const NEAR_PLANE: f32 = 0.1;
-const FAR_PLANE: f32 = 1000.0;
+const FAR_PLANE: f32 = 10000.0;
 
 fn computeDepth(ray: Ray, t: f32) -> f32 {
     let hitPoint = ray.origin + t * ray.direction;


### PR DESCRIPTION
This PR will cleanup various header files (scene and chunk), as well as add a slider in the ImGui window for scene scale, denoted as "resolution." It defaults to 4 octree depths per unit, i.e. 16x16x16 voxels per unit cube.

- Add dynamic scene chunk sizing, converting previous fixed values to reasonable defaults
- Add resolution slider in settings UI
  - To prevent silly buffer changes mid-render, the UI logic has been moved to run before scene rendering
- fix: for new scene scales, increase far plane depth from 1k to 10k units
  - (in future changes, this could be dynamic and/or based on render distance)
- cleanup: add comments and organize header files for scene and chunk