### PR TITLE
Add octree relaxation

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -394,14 +394,14 @@ auto Editor::handle_key_down(SDL_KeyboardEvent event, bool *quit) -> void {
         *quit = true;
         break;
     case SDLK_A:
+        // add random white block
         auto rand_pos =
             (glm::vec3(random_float(), random_float(), random_float()) -
              glm::vec3(0.5f)) *
             0.99f * this->scene.get_chunk_scale();
-        auto rand_depth = rand() % 5 + 4;
-        auto rand_color =
-            glm::u8vec4(rand() % 256, rand() % 256, rand() % 256, 255);
-        this->scene.set_voxel_filled(rand_depth, rand_pos, rand_color);
+        auto rand_depth = rand() % 3 + 1;
+        auto color = glm::u8vec4(255, 255, 255, 255);
+        this->scene.set_voxel_filled(rand_depth, rand_pos, color);
         break;
     }
 }

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -8,6 +8,21 @@
 
 namespace vxng::scene {
 
+auto VoxelData::operator==(const VoxelData &rhs) -> bool {
+    return this->color == rhs.color;
+}
+auto VoxelData::operator!=(const VoxelData &rhs) -> bool {
+    return !(*this == rhs);
+}
+
+auto OctreeNode::has_children() -> bool {
+    for (const auto &child : this->children) {
+        if (child)
+            return true;
+    }
+    return false;
+}
+
 // static stuffs
 wgpu::BindGroupLayout Chunk::bindgroup_layout = nullptr;
 bool Chunk::bindgroup_layout_created = false;
@@ -387,6 +402,46 @@ auto Chunk::build_buffer_data(std::vector<GPUOctreeNode> *octree_nodes,
         }
 
         octree_nodes->push_back(gpu_node);
+    }
+}
+
+auto Chunk::try_relax_up_from_node(OctreeNode *node) -> OctreeNode * {
+    OctreeNode *parent = node->parent;
+    if (!parent)
+        return node;
+
+    if (!node->is_leaf) {
+        // internal node: do nothing if still have any children
+        if (node->has_children())
+            return node;
+
+        // delete our node child
+        for (auto &child : parent->children) {
+            if (child.get() == node) {
+                child = nullptr;
+                break;
+            }
+        }
+
+        // recurse up octree
+        return try_relax_up_from_node(parent);
+    } else {
+        // node is leaf, try to join into parent if all children match
+
+        // end recursion if not all children match
+        VoxelData &node_data = node->leaf_data;
+        for (auto &child : parent->children) {
+            if (!child || child->leaf_data != node_data)
+                return node;
+        }
+
+        // copy leaf data to parent and set its children to nullptr
+        parent->is_leaf = true;
+        parent->leaf_data = node_data;
+        parent->children.fill(nullptr);
+
+        // traverse up octree
+        return try_relax_up_from_node(parent);
     }
 }
 

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -133,6 +133,7 @@ auto Chunk::set_voxel_filled(int depth, glm::vec3 local_position,
                              glm::u8vec4 color) -> void {
     if (!this->root_node) {
         this->root_node = std::make_unique<OctreeNode>();
+        this->root_node->parent = nullptr;
     }
     auto *node = this->root_node.get();
 
@@ -145,6 +146,7 @@ auto Chunk::set_voxel_filled(int depth, glm::vec3 local_position,
                 node->children[i] = std::make_unique<OctreeNode>();
                 auto &child = node->children[i];
 
+                child->parent = node;
                 child->is_leaf = true;
                 child->leaf_data = node->leaf_data;
             }
@@ -161,6 +163,7 @@ auto Chunk::set_voxel_filled(int depth, glm::vec3 local_position,
             node->children[child_index] = std::make_unique<OctreeNode>();
             auto &child = node->children[child_index];
 
+            child->parent = node;
             child->is_leaf = node_is_leaf;
             child->leaf_data = node->leaf_data;
         }

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -435,10 +435,10 @@ auto Chunk::try_relax_up_from_node(OctreeNode *node) -> OctreeNode * {
                 return node;
         }
 
-        // copy leaf data to parent and set its children to nullptr
+        // copy leaf data to parent and reset its children to nullptr
         parent->is_leaf = true;
         parent->leaf_data = node_data;
-        parent->children.fill(nullptr);
+        parent->children = {};
 
         // traverse up octree
         return try_relax_up_from_node(parent);

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -193,6 +193,9 @@ auto Chunk::set_voxel_filled(int depth, glm::vec3 local_position,
     node->is_leaf = true;
     node->leaf_data.color = color;
 
+    // relax upwards if possible
+    try_relax_up_from_node(node);
+
     // and of course update buffers for rendering
     update_buffers();
 };

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -12,6 +12,9 @@ namespace vxng::scene {
 
 typedef struct VoxelData {
     glm::u8vec4 color; // so much memory eek
+
+    auto operator==(const VoxelData &rhs) -> bool;
+    auto operator!=(const VoxelData &rhs) -> bool;
 } VoxelData;
 
 typedef struct OctreeNode {
@@ -19,6 +22,8 @@ typedef struct OctreeNode {
     bool is_leaf;
     VoxelData leaf_data;
     std::array<std::unique_ptr<OctreeNode>, 8> children;
+
+    auto has_children() -> bool;
 } OctreeNode;
 
 typedef struct GPUOctreeNode {
@@ -81,6 +86,16 @@ class Chunk {
     auto build_buffer_data(std::vector<GPUOctreeNode> *octree_nodes,
                            std::vector<GPUVoxelData> *voxel_datas) const
         -> void;
+
+    /**
+     * Recursively relax this chunk's octree, starting from the given node.
+     * Will only perform relaxation if the given node either:
+     *
+     * A) is a leaf node, or
+     *
+     * B) is an internal node, but the `children` array is all `nullptr`
+     */
+    auto try_relax_up_from_node(OctreeNode *node) -> OctreeNode *;
 
     glm::vec3 position;
     float scale;

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -15,6 +15,7 @@ typedef struct VoxelData {
 } VoxelData;
 
 typedef struct OctreeNode {
+    OctreeNode *parent;
     bool is_leaf;
     VoxelData leaf_data;
     std::array<std::unique_ptr<OctreeNode>, 8> children;

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -94,6 +94,9 @@ class Chunk {
      * A) is a leaf node, or
      *
      * B) is an internal node, but the `children` array is all `nullptr`
+     *
+     * Returns a pointer to the upmost relaxed resulting node, which will be the
+     * same as the input if no relaxation was performed.
      */
     auto try_relax_up_from_node(OctreeNode *node) -> OctreeNode *;
 


### PR DESCRIPTION
This PR will introduce an "octree relaxation" method, which should be called on any leaf-level updates in order to simplify the octree structure. It's a recursive method which:

If run on a leaf node, joins nodes as far up as possible given all children have the same leaf data
If run on an internal node, will delete the node from its parent if truly empty.

It then returns the highest-up relaxation result, which will be equivalent to its input if no relaxation occurred.

https://github.com/user-attachments/assets/879a48c8-5074-40e7-addf-ecdf5d422478

in the above video, if relaxation runs up to the root node, it will be turned red.

```cpp
// for testing, see if join successful:
if (!parent->parent) {
    parent->leaf_data = {
        glm::u8vec4(255, 0, 0, 255) // color
    };
} else {
    parent->leaf_data = node_data;
}
```

Changes:
- Add tracking of parent nodes to CPU-side octree nodes
- Add `Chunk::try_relax_up_from_node` method
  - Consumed upon adding leaf nodes
- patch: on random leaf filling, only add white (255, 255, 255) color leaves
