### PR TITLE
Add voxel deletion logic

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -393,7 +393,8 @@ auto Editor::handle_key_down(SDL_KeyboardEvent event, bool *quit) -> void {
     case SDLK_ESCAPE:
         *quit = true;
         break;
-    case SDLK_A:
+
+    case SDLK_A: {
         // add random white block
         auto rand_pos =
             (glm::vec3(random_float(), random_float(), random_float()) -
@@ -403,6 +404,18 @@ auto Editor::handle_key_down(SDL_KeyboardEvent event, bool *quit) -> void {
         auto color = glm::u8vec4(255, 255, 255, 255);
         this->scene.set_voxel_filled(rand_depth, rand_pos, color);
         break;
+    }
+
+    case SDLK_D: {
+        // delete random block
+        auto rand_pos =
+            (glm::vec3(random_float(), random_float(), random_float()) -
+             glm::vec3(0.5f)) *
+            0.99f * this->scene.get_chunk_scale();
+        auto rand_depth = rand() % 3 + 1;
+        this->scene.set_voxel_empty(rand_depth, rand_pos);
+        break;
+    }
     }
 }
 

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -28,6 +28,7 @@ class Scene {
 
     auto set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color)
         -> void;
+    auto set_voxel_empty(int depth, glm::vec3 position) -> void;
 
     // --------- Utility ---------
 

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -46,6 +46,26 @@ class Scene {
     int chunk_resolution;
     std::unordered_map<glm::ivec3, std::unique_ptr<Chunk>> chunks;
 
+    typedef struct ChunkedLocationInfo {
+        glm::ivec3 chunk_coord;
+        glm::vec3 local_position;
+    } LocationInfo;
+
+    /**
+     * Given a world position, get the chunk coord at said position as well as
+     * the position's chunk-local equivalent position
+     */
+    auto get_chunked_location_info(glm::vec3 position) const
+        -> ChunkedLocationInfo;
+
+    /**
+     * Instantiates chunk (and runs webgpu init) at given coords if chunk is not
+     * yet instantiated.
+     *
+     * @return pointer to the new or existing chunk.
+     */
+    auto touch_chunk(glm::ivec3 chunk_coord) -> Chunk *;
+
     struct {
         wgpu::Device device;
     } wgpu;

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -150,44 +150,8 @@ auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
 
 auto Chunk::set_voxel_filled(int depth, glm::vec3 local_position,
                              glm::u8vec4 color) -> void {
-    OctreeNode *node = this->root_node.get();
-
-    // create required nodes to specific depth
-    for (int trav_depth = 0; trav_depth < depth; ++trav_depth) {
-        bool node_is_leaf = node->is_leaf;
-        if (node_is_leaf) {
-            // if we were filled, then fill all children
-            for (int i = 0; i < 8; ++i) {
-                node->children[i] = std::make_unique<OctreeNode>();
-                auto &child = node->children[i];
-
-                child->parent = node;
-                child->is_leaf = true;
-                child->leaf_data = node->leaf_data;
-            }
-        }
-        node->is_leaf = false;
-
-        // dig into specific child node based on position
-        int child_index = ((uint32_t)(local_position.x >= 0) << 0) +
-                          ((uint32_t)(local_position.y >= 0) << 1) +
-                          ((uint32_t)(local_position.z >= 0) << 2);
-
-        // make child node if not exists
-        if (!node->children[child_index]) {
-            node->children[child_index] = std::make_unique<OctreeNode>();
-            auto &child = node->children[child_index];
-
-            child->parent = node;
-            child->is_leaf = node_is_leaf;
-            child->leaf_data = node->leaf_data;
-        }
-
-        // put local position into terms of new node bounds
-        local_position = glm::fract((local_position + glm::vec3(0.5f)) * 2.0f) -
-                         glm::vec3(0.5f);
-        node = node->children[child_index].get();
-    }
+    // dig first for the node we want to edit
+    OctreeNode *node = dig_into_tree(local_position, depth);
 
     // we have gotten to our desired depth, now just set active node to leaf
     node->is_leaf = true;

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <queue>
+#include <stdexcept>
 #include <vector>
 
 namespace vxng::scene {
@@ -405,6 +406,54 @@ auto Chunk::build_buffer_data(std::vector<GPUOctreeNode> *octree_nodes,
 
         octree_nodes->push_back(gpu_node);
     }
+}
+
+auto Chunk::dig_into_tree(glm::vec3 local_position, int depth) -> OctreeNode * {
+    OctreeNode *node = this->root_node.get();
+
+    if (depth < 0 || depth > glm::log2(this->resolution)) {
+        throw std::invalid_argument(
+            "Depth must be >= 0 and <= log2(resolution)");
+    }
+
+    // create required nodes to specific depth
+    for (int trav_depth = 0; trav_depth < depth; ++trav_depth) {
+        bool node_is_leaf = node->is_leaf;
+        if (node_is_leaf) {
+            // if we were filled, then fill all children
+            for (int i = 0; i < 8; ++i) {
+                node->children[i] = std::make_unique<OctreeNode>();
+                auto &child = node->children[i];
+
+                child->parent = node;
+                child->is_leaf = true;
+                child->leaf_data = node->leaf_data;
+            }
+        }
+        node->is_leaf = false;
+
+        // dig into specific child node based on position
+        int child_index = ((uint32_t)(local_position.x >= 0) << 0) +
+                          ((uint32_t)(local_position.y >= 0) << 1) +
+                          ((uint32_t)(local_position.z >= 0) << 2);
+
+        // make child node if not exists
+        if (!node->children[child_index]) {
+            node->children[child_index] = std::make_unique<OctreeNode>();
+            auto &child = node->children[child_index];
+
+            child->parent = node;
+            child->is_leaf = node_is_leaf;
+            child->leaf_data = node->leaf_data;
+        }
+
+        // put local position into terms of new node bounds
+        local_position = glm::fract((local_position + glm::vec3(0.5f)) * 2.0f) -
+                         glm::vec3(0.5f);
+        node = node->children[child_index].get();
+    }
+
+    return node;
 }
 
 auto Chunk::try_relax_up_from_node(OctreeNode *node) -> OctreeNode * {

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -2,6 +2,7 @@
 
 #include <webgpu/webgpu_cpp.h>
 
+#include <cmath>
 #include <memory>
 #include <queue>
 #include <stdexcept>
@@ -393,7 +394,7 @@ auto Chunk::build_buffer_data(std::vector<GPUOctreeNode> *octree_nodes,
 auto Chunk::dig_into_tree(glm::vec3 local_position, int depth) -> OctreeNode * {
     OctreeNode *node = this->root_node.get();
 
-    if (depth < 0 || depth > glm::log2(this->resolution)) {
+    if (depth < 0 || depth > std::log2(this->resolution)) {
         throw std::invalid_argument(
             "Depth must be >= 0 and <= log2(resolution)");
     }

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -164,6 +164,24 @@ auto Chunk::set_voxel_filled(int depth, glm::vec3 local_position,
     update_buffers();
 };
 
+auto Chunk::set_voxel_empty(int depth, glm::vec3 local_position) -> void {
+    // dig first for the node we want to edit
+    OctreeNode *node = dig_into_tree(local_position, depth);
+
+    // we have gotten to our desired depth, now just set active node to leaf
+    node->is_leaf = false;
+    node->children = {};
+
+    // could be optimized by digging to the depth 1 above, then just setting the
+    // matching child to nullptr
+
+    // relax upwards if possible
+    try_relax_up_from_node(node);
+
+    // and of course update buffers for rendering
+    update_buffers();
+}
+
 auto Chunk::reposition(glm::vec3 pos, float scale) -> void {
     this->position = pos;
     this->scale = scale;

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -28,7 +28,10 @@ wgpu::BindGroupLayout Chunk::bindgroup_layout = nullptr;
 bool Chunk::bindgroup_layout_created = false;
 
 Chunk::Chunk(glm::vec3 pos, float scale, int resolution)
-    : position(pos), scale(scale), resolution(resolution) {};
+    : position(pos), scale(scale), resolution(resolution) {
+    this->root_node = std::make_unique<OctreeNode>();
+    this->root_node->parent = nullptr;
+};
 
 Chunk::~Chunk() {
     if (!this->wgpu.initialized)
@@ -60,8 +63,8 @@ auto Chunk::get_bounds() const -> geometry::AABB {
 }
 
 auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
-    // If no octree, return miss
-    if (!root_node) {
+    // If not leaf but no children, return miss
+    if (!root_node->is_leaf && !root_node->has_children()) {
         return geometry::RaycastResult{-1.0f, glm::vec3(0.0f)};
     }
 
@@ -146,11 +149,7 @@ auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
 
 auto Chunk::set_voxel_filled(int depth, glm::vec3 local_position,
                              glm::u8vec4 color) -> void {
-    if (!this->root_node) {
-        this->root_node = std::make_unique<OctreeNode>();
-        this->root_node->parent = nullptr;
-    }
-    auto *node = this->root_node.get();
+    OctreeNode *node = this->root_node.get();
 
     // create required nodes to specific depth
     for (int trav_depth = 0; trav_depth < depth; ++trav_depth) {

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -59,6 +59,7 @@ class Chunk {
 
     auto set_voxel_filled(int depth, glm::vec3 local_position,
                           glm::u8vec4 color) -> void;
+    auto set_voxel_empty(int depth, glm::vec3 local_position) -> void;
 
     // --------- Utility ---------
 

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -88,6 +88,15 @@ class Chunk {
         -> void;
 
     /**
+     * Dig into the octree, splitting nodes into children if necessary to reach
+     * the given depth. Returns a pointer to the node at the given depth.
+     *
+     * @param local_position  An internal voxel position, in range [-0.5, 0.5]
+     * @param depth           The depth to dig, maxing out at `log2(resolution)`
+     */
+    auto dig_into_tree(glm::vec3 local_position, int depth) -> OctreeNode *;
+
+    /**
      * Recursively relax this chunk's octree, starting from the given node.
      * Will only perform relaxation if the given node either:
      *

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -72,6 +72,13 @@ auto Scene::set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color)
                                    color);
 }
 
+auto Scene::set_voxel_empty(int depth, glm::vec3 position) -> void {
+    auto chunked_location = get_chunked_location_info(position);
+    Chunk *target_chunk = touch_chunk(chunked_location.chunk_coord);
+
+    target_chunk->set_voxel_empty(depth, chunked_location.local_position);
+}
+
 auto Scene::get_chunk_scale() const -> float { return this->chunk_scale; }
 
 auto Scene::get_chunk_resolution() const -> int {

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -96,4 +96,35 @@ auto Scene::set_chunk_scale(float new_scale) -> void {
     }
 }
 
+auto Scene::get_chunked_location_info(glm::vec3 position) const
+    -> ChunkedLocationInfo {
+    glm::ivec3 chunk_coord = glm::floor(
+        (position + glm::vec3(this->chunk_scale * 0.5f)) / this->chunk_scale);
+    glm::vec3 chunk_origin = glm::vec3(chunk_coord) * this->chunk_scale;
+    glm::vec3 local_position = (position - chunk_origin) / this->chunk_scale;
+
+    return ChunkedLocationInfo{
+        .chunk_coord = chunk_coord,
+        .local_position = local_position,
+    };
+}
+
+auto Scene::touch_chunk(glm::ivec3 chunk_coord) -> Chunk * {
+    // if chunk already exists just grab it
+    if (this->chunks.find(chunk_coord) != this->chunks.end()) {
+        return this->chunks[chunk_coord].get();
+    }
+
+    // otherwise, we gotta create the chunk
+    glm::vec3 chunk_origin = glm::vec3(chunk_coord) * this->chunk_scale;
+    this->chunks[chunk_coord] = std::make_unique<Chunk>(
+        chunk_origin, this->chunk_scale, this->chunk_resolution);
+    auto &new_chunk = this->chunks[chunk_coord];
+
+    // and init webgpu
+    new_chunk->init_webgpu(this->wgpu.device);
+
+    return new_chunk.get();
+}
+
 } // namespace vxng::scene

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -65,18 +65,11 @@ auto Scene::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
 
 auto Scene::set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color)
     -> void {
-    glm::ivec3 chunk_coord = glm::floor(
-        (position + glm::vec3(this->chunk_scale * 0.5f)) / this->chunk_scale);
-    glm::vec3 chunk_origin = (glm::vec3(chunk_coord) * this->chunk_scale);
-    glm::vec3 local_position = (position - chunk_origin) / this->chunk_scale;
+    auto chunked_location = get_chunked_location_info(position);
+    Chunk *target_chunk = touch_chunk(chunked_location.chunk_coord);
 
-    if (!this->chunks[chunk_coord]) {
-        this->chunks[chunk_coord] = std::make_unique<Chunk>(
-            chunk_origin, this->chunk_scale, this->chunk_resolution);
-        this->chunks[chunk_coord]->init_webgpu(this->wgpu.device);
-    }
-
-    this->chunks[chunk_coord]->set_voxel_filled(depth, local_position, color);
+    target_chunk->set_voxel_filled(depth, chunked_location.local_position,
+                                   color);
 }
 
 auto Scene::get_chunk_scale() const -> float { return this->chunk_scale; }


### PR DESCRIPTION
This PR will add public voxel deletion methods for `Chunk` and `Scene`, as well as a quick keybind `[D]` for random deletion for testing. As a part of this, it introduces some useful helpers shared by voxel addition and deletion methods.

## Changes:

- Add `set_voxel_empty` methods for `Chunk` and `Scene`
  - Consumed by pressing `[D]` for now
- Add helpers for chunk and scene manipulation
  - Add private `Chunk::dig_into_tree` helper
  - Add private `Scene::get_chunked_location_info` helper for translating world coords into local chunk info
  - Add private `Scene::touch_chunk` to create and initialize a chunk if not yet created
- Consume new helpers in old and new voxel editing methods
- patch: instantiate root node in `Chunk` constructor instead of lazily
