### PR TITLE
Add tools system with basic voxel brush

### DIFF
--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(${PROJECT_NAME})
 
 target_sources(${PROJECT_NAME}
     PRIVATE
+        src/tools/voxel-brush.cpp
         src/cursors.cpp
         src/editor.cpp
         src/main.cpp

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(${PROJECT_NAME})
 
 target_sources(${PROJECT_NAME}
     PRIVATE
+        src/cursors.cpp
         src/editor.cpp
         src/main.cpp
         src/tool.cpp

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(${PROJECT_NAME}
     PRIVATE
         src/editor.cpp
         src/main.cpp
+        src/tool.cpp
 )
 
 target_include_directories(${PROJECT_NAME}

--- a/editor/src/cursors.cpp
+++ b/editor/src/cursors.cpp
@@ -1,0 +1,19 @@
+#include "cursors.h"
+
+Cursors::Cursors() {}
+Cursors::~Cursors() {}
+
+auto Cursors::setup_sdl_cursors() -> void {
+    this->sdl_cursors[Variant::DEFAULT] =
+        SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_DEFAULT);
+    this->sdl_cursors[Variant::POINTER] =
+        SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_POINTER);
+    this->sdl_cursors[Variant::MOVE] =
+        SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_MOVE);
+    this->sdl_cursors[Variant::NS_RESIZE] =
+        SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NS_RESIZE);
+}
+
+auto Cursors::set_cursor(Variant variant) -> void {
+    SDL_SetCursor(this->sdl_cursors[variant]);
+}

--- a/editor/src/cursors.h
+++ b/editor/src/cursors.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SDL3/SDL.h>
+
 #include <map>
 
 typedef class Cursors {

--- a/editor/src/cursors.h
+++ b/editor/src/cursors.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <SDL3/SDL.h>
+#include <map>
+
+typedef class Cursors {
+  public:
+    typedef enum Variant { DEFAULT, POINTER, MOVE, NS_RESIZE } Variant;
+
+    Cursors();
+    ~Cursors();
+    auto setup_sdl_cursors() -> void;
+    auto set_cursor(Variant variant) -> void;
+
+  private:
+    std::map<Variant, SDL_Cursor *> sdl_cursors;
+} Cursors;

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -1,18 +1,21 @@
 #include "editor.h"
 
-#include "vxng/vxng.h"
+#include "cursors.h"
 
 #include <SDL3/SDL.h>
 #include <imgui.h>
 #include <imgui_impl_sdl3.h>
 #include <imgui_impl_wgpu.h>
 #include <sdl3webgpu.h>
+#include <vxng/vxng.h>
 #include <webgpu/webgpu_cpp.h>
 
 #include <cstdlib>
 #include <iostream>
 
-Editor::Editor() : renderer(), viewport_camera(), scene(512, 32.f) {};
+Editor::Editor()
+    : renderer(), viewport_camera(), scene(512, 32.f), cursors(), tools(),
+      current_tool(&tools.voxel_brush) {};
 
 auto Editor::init() -> int {
 
@@ -39,12 +42,7 @@ auto Editor::init() -> int {
     }
 
     // setup sdl cursors
-    this->cursors.normal = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_DEFAULT);
-    this->cursors.pointer = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_POINTER);
-    this->cursors.orbit_camera = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_MOVE);
-    this->cursors.pan_camera = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_MOVE);
-    this->cursors.zoom_camera =
-        SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NS_RESIZE);
+    this->cursors.setup_sdl_cursors();
 
     // setup webgpu instance
     wgpu::InstanceDescriptor instance_desc = {};
@@ -364,10 +362,28 @@ auto Editor::poll_events(bool &quit) -> void {
             handle_key_down(evt.key, &quit);
             break;
 
+        case SDL_EVENT_KEY_UP:
+            if (io.WantCaptureKeyboard) // imgui takes precedence
+                break;
+            handle_key_up(evt.key);
+            break;
+
         case SDL_EVENT_MOUSE_MOTION:
             if (io.WantCaptureMouse) // imgui takes precedence
                 break;
             handle_mouse_motion(evt.motion);
+            break;
+
+        case SDL_EVENT_MOUSE_BUTTON_DOWN:
+            if (io.WantCaptureMouse) // imgui takes precedence
+                break;
+            handle_mouse_down(evt.button);
+            break;
+
+        case SDL_EVENT_MOUSE_BUTTON_UP:
+            if (io.WantCaptureMouse) // imgui takes precedence
+                break;
+            handle_mouse_up(evt.button);
             break;
         }
     }
@@ -388,7 +404,8 @@ auto random_float() -> float {
     return static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
 }
 
-auto Editor::handle_key_down(SDL_KeyboardEvent event, bool *quit) -> void {
+auto Editor::handle_key_down(const SDL_KeyboardEvent &event, bool *quit)
+    -> void {
     switch (event.key) {
     case SDLK_ESCAPE:
         *quit = true;
@@ -416,31 +433,88 @@ auto Editor::handle_key_down(SDL_KeyboardEvent event, bool *quit) -> void {
         this->scene.set_voxel_empty(rand_depth, rand_pos);
         break;
     }
+
+    default: {
+        // pass off to current tool
+        glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
+        this->current_tool->handle_keyboard_event(
+            EditorTool::KeyboardEventBundle{
+                .event = &event,
+                .mouse_ndc_coords = mouse_ndc_pos,
+                .scene = &this->scene,
+                .camera = &this->viewport_camera,
+                .cursors = &this->cursors,
+            });
+    }
     }
 }
 
-auto Editor::handle_mouse_motion(SDL_MouseMotionEvent event) -> void {
+auto Editor::handle_key_up(const SDL_KeyboardEvent &event) -> void {
+    // pass off to current tool
+    glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
+    this->current_tool->handle_keyboard_event(EditorTool::KeyboardEventBundle{
+        .event = &event,
+        .mouse_ndc_coords = mouse_ndc_pos,
+        .scene = &this->scene,
+        .camera = &this->viewport_camera,
+        .cursors = &this->cursors,
+    });
+}
+
+auto Editor::handle_mouse_motion(const SDL_MouseMotionEvent &event) -> void {
     SDL_Keymod mods = SDL_GetModState();
 
     // camera movement (only if alt is held)
     if (mods & SDL_KMOD_ALT) {
         if (event.state & SDL_BUTTON_LMASK) {
             this->viewport_camera.handle_rotation(event.xrel, event.yrel);
-            SDL_SetCursor(this->cursors.orbit_camera);
+            this->cursors.set_cursor(Cursors::Variant::MOVE);
         } else if (event.state & SDL_BUTTON_RMASK) {
             this->viewport_camera.handle_zoom(event.yrel);
-            SDL_SetCursor(this->cursors.zoom_camera);
+            this->cursors.set_cursor(Cursors::Variant::NS_RESIZE);
         } else if (event.state & SDL_BUTTON_MMASK) {
             this->viewport_camera.handle_pan(event.xrel, event.yrel);
-            SDL_SetCursor(this->cursors.pan_camera);
+            this->cursors.set_cursor(Cursors::Variant::MOVE);
         }
     } else {
-        // no button held, track mouse position
-        update_pointer_target();
+        // no mod held, pass off to current tool
+        glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
+        this->current_tool->handle_mouse_motion_event(
+            EditorTool::MouseMotionEventBundle{
+                .event = &event,
+                .mouse_ndc_coords = mouse_ndc_pos,
+                .scene = &this->scene,
+                .camera = &this->viewport_camera,
+                .cursors = &this->cursors,
+            });
     }
 }
 
-auto Editor::update_pointer_target() -> void {
+auto Editor::handle_mouse_down(const SDL_MouseButtonEvent &event) -> void {
+    glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
+    this->current_tool->handle_mouse_button_event(
+        EditorTool::MouseButtonEventBundle{
+            .event = &event,
+            .mouse_ndc_coords = mouse_ndc_pos,
+            .scene = &this->scene,
+            .camera = &this->viewport_camera,
+            .cursors = &this->cursors,
+        });
+}
+
+auto Editor::handle_mouse_up(const SDL_MouseButtonEvent &event) -> void {
+    glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
+    this->current_tool->handle_mouse_button_event(
+        EditorTool::MouseButtonEventBundle{
+            .event = &event,
+            .mouse_ndc_coords = mouse_ndc_pos,
+            .scene = &this->scene,
+            .camera = &this->viewport_camera,
+            .cursors = &this->cursors,
+        });
+}
+
+auto Editor::get_mouse_ndc_coords() const -> glm::vec2 {
     glm::vec2 screen_pos;
     SDL_GetMouseState(&screen_pos.x, &screen_pos.y);
     glm::ivec2 screen_size;
@@ -450,22 +524,5 @@ auto Editor::update_pointer_target() -> void {
     screen_pos /= screen_size;
 
     // flip y and scale both to [-1, 1]
-    screen_pos = (screen_pos - glm::vec2(0.5)) * glm::vec2(2.f, -2.f);
-
-    // get racyast pos in threespace
-    vxng::geometry::Ray ray = this->viewport_camera.screen_to_ray(screen_pos);
-    vxng::geometry::RaycastResult raycast_result = this->scene.raycast(ray);
-
-    if (raycast_result.t >= 0.f) {
-        glm::vec3 world_pos = ray.origin + raycast_result.t * ray.direction;
-        this->pointer.target = world_pos;
-        this->pointer.normal = raycast_result.normal;
-        this->pointer.is_active = true;
-
-        SDL_SetCursor(this->cursors.pointer);
-    } else {
-        this->pointer.is_active = false;
-
-        SDL_SetCursor(this->cursors.normal);
-    }
+    return (screen_pos - glm::vec2(0.5)) * glm::vec2(2.f, -2.f);
 }

--- a/editor/src/editor.h
+++ b/editor/src/editor.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#include "vxng/vxng.h"
+#include "cursors.h"
+#include "tool.h"
+#include "tools/tools.h"
+
+#include <vxng/vxng.h>
 
 #include <SDL3/SDL.h>
 #include <imgui.h>
@@ -35,17 +39,23 @@ class Editor {
 
     auto poll_events(bool &quit) -> void;
     auto handle_resize(int width, int height) -> void;
-    auto handle_key_down(SDL_KeyboardEvent event, bool *quit) -> void;
-    auto handle_mouse_motion(SDL_MouseMotionEvent event) -> void;
+    auto handle_key_down(const SDL_KeyboardEvent &event, bool *quit) -> void;
+    auto handle_key_up(const SDL_KeyboardEvent &event) -> void;
+    auto handle_mouse_motion(const SDL_MouseMotionEvent &event) -> void;
+    auto handle_mouse_down(const SDL_MouseButtonEvent &event) -> void;
+    auto handle_mouse_up(const SDL_MouseButtonEvent &event) -> void;
 
     struct {
         bool is_active;
         glm::vec3 target, normal;
     } pointer;
 
-    struct {
-        SDL_Cursor *normal, *pointer, *orbit_camera, *zoom_camera, *pan_camera;
-    } cursors;
+    Cursors cursors;
 
-    auto update_pointer_target() -> void;
+    struct {
+        VoxelBrush voxel_brush;
+    } tools;
+    EditorTool *current_tool;
+
+    auto get_mouse_ndc_coords() const -> glm::vec2;
 };

--- a/editor/src/tool.cpp
+++ b/editor/src/tool.cpp
@@ -1,0 +1,5 @@
+#include "tool.h"
+
+EditorTool::EditorTool() {}
+
+EditorTool::~EditorTool() {}

--- a/editor/src/tool.h
+++ b/editor/src/tool.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <vxng/vxng.h>
+
+#include <SDL3/SDL.h>
+
+typedef struct KeyboardEventBundle {
+    const SDL_KeyboardEvent *event;
+    glm::vec2 mouse_ndc_coords;
+    vxng::scene::Scene *scene;
+    vxng::camera::Camera *camera;
+} KeyboardEventBundle;
+
+typedef struct MouseButtonEventBundle {
+    const SDL_MouseButtonEvent *event;
+    glm::vec2 mouse_ndc_coords;
+    vxng::scene::Scene *scene;
+    vxng::camera::Camera *camera;
+} MouseButtonEventBundle;
+
+typedef struct MouseMotionEventBundle {
+    const SDL_MouseMotionEvent *event;
+    glm::vec2 mouse_ndc_coords;
+    vxng::scene::Scene *scene;
+    vxng::camera::Camera *camera;
+} MouseMotionEventBundle;
+
+class EditorTool {
+  public:
+    EditorTool();
+    ~EditorTool();
+
+    virtual auto get_tool_name() -> const char * = 0;
+    virtual auto render_ui() -> void = 0;
+
+    virtual auto handle_mouse_button_event(const MouseButtonEventBundle &bundle)
+        -> void = 0;
+    virtual auto handle_mouse_motion_event(const MouseMotionEventBundle &bundle)
+        -> void = 0;
+    virtual auto handle_keyboard_event(const KeyboardEventBundle &bundle)
+        -> void = 0;
+};

--- a/editor/src/tool.h
+++ b/editor/src/tool.h
@@ -5,6 +5,10 @@
 #include <SDL3/SDL.h>
 #include <vxng/vxng.h>
 
+/**
+ * This abstract class should be implemented by actual tools. See implemented
+ * tools in the `src/tools/` directory.
+ */
 class EditorTool {
   public:
     EditorTool();

--- a/editor/src/tool.h
+++ b/editor/src/tool.h
@@ -1,14 +1,16 @@
 #pragma once
 
-#include <vxng/vxng.h>
+#include "cursors.h"
 
 #include <SDL3/SDL.h>
+#include <vxng/vxng.h>
 
 typedef struct KeyboardEventBundle {
     const SDL_KeyboardEvent *event;
     glm::vec2 mouse_ndc_coords;
     vxng::scene::Scene *scene;
     vxng::camera::Camera *camera;
+    Cursors *cursors;
 } KeyboardEventBundle;
 
 typedef struct MouseButtonEventBundle {
@@ -16,6 +18,7 @@ typedef struct MouseButtonEventBundle {
     glm::vec2 mouse_ndc_coords;
     vxng::scene::Scene *scene;
     vxng::camera::Camera *camera;
+    Cursors *cursors;
 } MouseButtonEventBundle;
 
 typedef struct MouseMotionEventBundle {
@@ -23,6 +26,7 @@ typedef struct MouseMotionEventBundle {
     glm::vec2 mouse_ndc_coords;
     vxng::scene::Scene *scene;
     vxng::camera::Camera *camera;
+    Cursors *cursors;
 } MouseMotionEventBundle;
 
 class EditorTool {

--- a/editor/src/tool.h
+++ b/editor/src/tool.h
@@ -5,30 +5,6 @@
 #include <SDL3/SDL.h>
 #include <vxng/vxng.h>
 
-typedef struct KeyboardEventBundle {
-    const SDL_KeyboardEvent *event;
-    glm::vec2 mouse_ndc_coords;
-    vxng::scene::Scene *scene;
-    vxng::camera::Camera *camera;
-    Cursors *cursors;
-} KeyboardEventBundle;
-
-typedef struct MouseButtonEventBundle {
-    const SDL_MouseButtonEvent *event;
-    glm::vec2 mouse_ndc_coords;
-    vxng::scene::Scene *scene;
-    vxng::camera::Camera *camera;
-    Cursors *cursors;
-} MouseButtonEventBundle;
-
-typedef struct MouseMotionEventBundle {
-    const SDL_MouseMotionEvent *event;
-    glm::vec2 mouse_ndc_coords;
-    vxng::scene::Scene *scene;
-    vxng::camera::Camera *camera;
-    Cursors *cursors;
-} MouseMotionEventBundle;
-
 class EditorTool {
   public:
     EditorTool();
@@ -36,6 +12,30 @@ class EditorTool {
 
     virtual auto get_tool_name() -> const char * = 0;
     virtual auto render_ui() -> void = 0;
+
+    typedef struct KeyboardEventBundle {
+        const SDL_KeyboardEvent *event;
+        glm::vec2 mouse_ndc_coords;
+        vxng::scene::Scene *scene;
+        vxng::camera::Camera *camera;
+        Cursors *cursors;
+    } KeyboardEventBundle;
+
+    typedef struct MouseButtonEventBundle {
+        const SDL_MouseButtonEvent *event;
+        glm::vec2 mouse_ndc_coords;
+        vxng::scene::Scene *scene;
+        vxng::camera::Camera *camera;
+        Cursors *cursors;
+    } MouseButtonEventBundle;
+
+    typedef struct MouseMotionEventBundle {
+        const SDL_MouseMotionEvent *event;
+        glm::vec2 mouse_ndc_coords;
+        vxng::scene::Scene *scene;
+        vxng::camera::Camera *camera;
+        Cursors *cursors;
+    } MouseMotionEventBundle;
 
     virtual auto handle_mouse_button_event(const MouseButtonEventBundle &bundle)
         -> void = 0;

--- a/editor/src/tools/tools.h
+++ b/editor/src/tools/tools.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "voxel-brush.h" // IWYU pragma: export

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -1,6 +1,5 @@
 #include "voxel-brush.h"
 
-#include "SDL3/SDL_mouse.h"
 #include "cursors.h"
 
 VoxelBrush::VoxelBrush() {}
@@ -62,6 +61,7 @@ auto VoxelBrush::handle_mouse_motion_event(const MouseMotionEventBundle &bundle)
     auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
     auto raycast_result = bundle.scene->raycast(mouse_ray);
 
+    // set pointer to "cursor" if raycast hit something
     if (raycast_result.t >= 0) {
         bundle.cursors->set_cursor(Cursors::Variant::POINTER);
     } else {

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -1,0 +1,49 @@
+#include "voxel-brush.h"
+#include "cursors.h"
+
+VoxelBrush::VoxelBrush() {}
+
+VoxelBrush::~VoxelBrush() {}
+
+auto VoxelBrush::get_tool_name() -> const char * {
+    return "Simple Voxel Brush";
+}
+
+// no ui for this yet
+auto VoxelBrush::render_ui() -> void {}
+
+auto VoxelBrush::handle_mouse_button_event(const MouseButtonEventBundle &bundle)
+    -> void {
+    auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
+    auto raycast_result = bundle.scene->raycast(mouse_ray);
+
+    // if nothing hit, do nothing
+    if (raycast_result.t < 0) {
+        return;
+    }
+
+    glm::vec3 target_pos =
+        mouse_ray.origin + raycast_result.t * mouse_ray.direction;
+    // go outside of voxel boundary
+    glm::vec3 exterior_target_pos =
+        target_pos + raycast_result.normal * 0.0001f;
+
+    // set voxel filled!
+    bundle.scene->set_voxel_filled(9, exterior_target_pos,
+                                   glm::u8vec4(255, 255, 255, 255));
+}
+
+auto VoxelBrush::handle_mouse_motion_event(const MouseMotionEventBundle &bundle)
+    -> void {
+    auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
+    auto raycast_result = bundle.scene->raycast(mouse_ray);
+
+    if (raycast_result.t >= 0) {
+        bundle.cursors->set_cursor(Cursors::Variant::POINTER);
+    } else {
+        bundle.cursors->set_cursor(Cursors::Variant::DEFAULT);
+    }
+}
+
+auto VoxelBrush::handle_keyboard_event(const KeyboardEventBundle &bundle)
+    -> void {}

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -1,5 +1,6 @@
 #include "voxel-brush.h"
 
+#include "SDL3/SDL_mouse.h"
 #include "cursors.h"
 
 VoxelBrush::VoxelBrush() {}
@@ -34,12 +35,26 @@ auto VoxelBrush::handle_mouse_button_event(const MouseButtonEventBundle &bundle)
 
     glm::vec3 target_pos =
         mouse_ray.origin + raycast_result.t * mouse_ray.direction;
-    // go outside of voxel boundary
-    glm::vec3 exterior_target_pos = target_pos + raycast_result.normal * 0.001f;
 
     // set voxel filled!
-    bundle.scene->set_voxel_filled(9, exterior_target_pos,
-                                   glm::u8vec4(255, 0, 0, 255));
+    switch (bundle.event->button) {
+    case SDL_BUTTON_LEFT: {
+        // go outside of voxel boundary
+        glm::vec3 exterior_target_pos =
+            target_pos + raycast_result.normal * 0.00001f;
+
+        bundle.scene->set_voxel_filled(9, exterior_target_pos,
+                                       glm::u8vec4(255, 0, 0, 255));
+        break;
+    }
+    case SDL_BUTTON_RIGHT: {
+        // go inside voxel boundary
+        glm::vec3 interior_target_pos =
+            target_pos - raycast_result.normal * 0.00001f;
+        bundle.scene->set_voxel_empty(9, interior_target_pos);
+        break;
+    }
+    }
 }
 
 auto VoxelBrush::handle_mouse_motion_event(const MouseMotionEventBundle &bundle)

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -1,4 +1,5 @@
 #include "voxel-brush.h"
+
 #include "cursors.h"
 
 VoxelBrush::VoxelBrush() {}
@@ -14,6 +15,15 @@ auto VoxelBrush::render_ui() -> void {}
 
 auto VoxelBrush::handle_mouse_button_event(const MouseButtonEventBundle &bundle)
     -> void {
+    // we don't care about mouse up
+    if (!bundle.event->down)
+        return;
+
+    // don't do anything if any mods are held
+    SDL_Keymod mods = SDL_GetModState();
+    if (mods != SDL_KMOD_NONE)
+        return;
+
     auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
     auto raycast_result = bundle.scene->raycast(mouse_ray);
 
@@ -25,12 +35,11 @@ auto VoxelBrush::handle_mouse_button_event(const MouseButtonEventBundle &bundle)
     glm::vec3 target_pos =
         mouse_ray.origin + raycast_result.t * mouse_ray.direction;
     // go outside of voxel boundary
-    glm::vec3 exterior_target_pos =
-        target_pos + raycast_result.normal * 0.0001f;
+    glm::vec3 exterior_target_pos = target_pos + raycast_result.normal * 0.001f;
 
     // set voxel filled!
     bundle.scene->set_voxel_filled(9, exterior_target_pos,
-                                   glm::u8vec4(255, 255, 255, 255));
+                                   glm::u8vec4(255, 0, 0, 255));
 }
 
 auto VoxelBrush::handle_mouse_motion_event(const MouseMotionEventBundle &bundle)

--- a/editor/src/tools/voxel-brush.h
+++ b/editor/src/tools/voxel-brush.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "tool.h"
+
+class VoxelBrush : public EditorTool {
+  public:
+    VoxelBrush();
+    ~VoxelBrush();
+
+    auto get_tool_name() -> const char * override;
+    auto render_ui() -> void override;
+
+    auto handle_mouse_button_event(const MouseButtonEventBundle &bundle)
+        -> void override;
+    auto handle_mouse_motion_event(const MouseMotionEventBundle &bundle)
+        -> void override;
+    auto handle_keyboard_event(const KeyboardEventBundle &bundle)
+        -> void override;
+};

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -29,11 +29,8 @@ Scene::Scene()
 Scene::~Scene() {}
 
 auto Scene::init_webgpu(wgpu::Device device) -> void {
-    auto origin_chunk = std::make_unique<Chunk>(glm::vec3(0), 4.0, 512);
-    origin_chunk->init_webgpu(device);
-
-    this->chunks[glm::ivec3(0)] = std::move(origin_chunk);
     this->wgpu.device = device;
+    touch_chunk(glm::ivec3(0.f));
 }
 
 auto Scene::get_chunks() const


### PR DESCRIPTION
## Description

This PR will introduce an abstracted "tools" system to allow for speedy creation of various tool archetypes. Tools implement the abstract class `EditorTool`, and are allowed to hook into various events such as keypresses, mouse movements, and mouse button presses.

This initial PR comes with a basic voxel brush tool. See it in action below.

https://github.com/user-attachments/assets/b0a50ce2-b61e-4584-9467-b5f3d127e904

## Changes

- Add abstracted `EditorTool` class
- Add `Cursors` class to abstract cursor switching
- Consume tools and cursor class in `Editor`
- Add basic voxel brush, implementing `EditorTool`
  - Left click to add, right click to delete. Operates at the deepest depth.
- fix: chunk sizing should be correct from the start
- patch: replace `Editor::update_pointer_target` with `Editor::get_mouse_ndc_coords` for use with tools.

## Notes

Testing this PR has revealed some bugs in octree traversal when raycasting from inside an internal node. This should be fixed next.

## Next steps

- Fix CPU raycasting logic
- Add editor-level color swatch
- Add UI for tools + switching