### PR TITLE
Add more CPU raycast result data, fix behavior

### DIFF
--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -27,8 +27,8 @@ auto VoxelBrush::handle_mouse_button_event(const MouseButtonEventBundle &bundle)
     auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
     auto raycast_result = bundle.scene->raycast(mouse_ray);
 
-    // if nothing hit, do nothing
-    if (raycast_result.t < 0) {
+    // if nothing hit or we're inside something, do nothing
+    if (!raycast_result.hit || raycast_result.inside) {
         return;
     }
 

--- a/libs/vxng/include/vxng/geometry.h
+++ b/libs/vxng/include/vxng/geometry.h
@@ -21,7 +21,9 @@ typedef struct RayAABBIntersectResult {
 } RayAABBIntersectResult;
 
 typedef struct RaycastResult {
-    float t; // Should be -1 if nothing hit
+    bool hit;
+    float t;
+    bool inside;
     glm::vec3 normal;
 } RaycastResult;
 

--- a/libs/vxng/include/vxng/geometry.h
+++ b/libs/vxng/include/vxng/geometry.h
@@ -14,6 +14,12 @@ typedef struct AABB {
     glm::vec3 max;
 } AABB;
 
+typedef struct RayAABBIntersectResult {
+    bool hit;
+    float t;
+    bool inside;
+} RayAABBIntersectResult;
+
 typedef struct RaycastResult {
     float t; // Should be -1 if nothing hit
     glm::vec3 normal;
@@ -22,7 +28,8 @@ typedef struct RaycastResult {
 /**
  * Checks if a ray intersects an axis-aligned box (AABB).
  */
-auto ray_aabb_intersect(const Ray &ray, const AABB &aabb, float *t) -> bool;
+auto ray_aabb_intersect(const Ray &ray, const AABB &aabb)
+    -> RayAABBIntersectResult;
 
 /**
  * Computes the normal of the intersection point with an octant (AABB).

--- a/libs/vxng/src/geometry.cpp
+++ b/libs/vxng/src/geometry.cpp
@@ -31,11 +31,11 @@ auto ray_aabb_intersect(const Ray &ray, const AABB &aabb)
         return RayAABBIntersectResult{.hit = false};
     }
 
-    // Report if inside
+    // Report if inside, and use tFar
     if (tNear < 0.0f)
         return RayAABBIntersectResult{
             .hit = true,
-            .t = 0.0f,
+            .t = tFar,
             .inside = true,
         };
 

--- a/libs/vxng/src/geometry.cpp
+++ b/libs/vxng/src/geometry.cpp
@@ -3,7 +3,8 @@
 namespace vxng::geometry {
 
 // implementation based on libs/vxng/src/wgsl/chunk.wgsl.cpp
-auto ray_aabb_intersect(const Ray &ray, const AABB &aabb, float *t) -> bool {
+auto ray_aabb_intersect(const Ray &ray, const AABB &aabb)
+    -> RayAABBIntersectResult {
     const float invDirX = 1.0f / ray.direction.x;
     const float invDirY = 1.0f / ray.direction.y;
     const float invDirZ = 1.0f / ray.direction.z;
@@ -27,11 +28,22 @@ auto ray_aabb_intersect(const Ray &ray, const AABB &aabb, float *t) -> bool {
     float tFar = std::min({t1X, t1Y, t1Z});
 
     if (tNear > tFar) {
-        return false;
+        return RayAABBIntersectResult{.hit = false};
     }
 
-    *t = tNear;
-    return true;
+    // Report if inside
+    if (tNear < 0.0f)
+        return RayAABBIntersectResult{
+            .hit = true,
+            .t = 0.0f,
+            .inside = true,
+        };
+
+    return RayAABBIntersectResult{
+        .hit = true,
+        .t = tNear,
+        .inside = false,
+    };
 }
 
 auto compute_aabb_normal(const AABB &aabb, glm::vec3 intersection)

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -67,7 +67,7 @@ auto Chunk::get_bounds() const -> geometry::AABB {
 auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
     // If not leaf but no children, return miss
     if (!root_node->is_leaf && !root_node->has_children()) {
-        return geometry::RaycastResult{-1.0f, glm::vec3(0.0f)};
+        return geometry::RaycastResult{.hit = false};
     }
 
     // Compute root AABB from chunk position and scale
@@ -75,7 +75,7 @@ auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
 
     // Check if ray hits root AABB at all
     if (!geometry::ray_aabb_intersect(ray, root_aabb).hit) {
-        return geometry::RaycastResult{-1.0f, glm::vec3(0.0f)};
+        return geometry::RaycastResult{.hit = false};
     }
 
     // Stack for iterative DFS traversal
@@ -87,7 +87,7 @@ auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
     std::vector<StackEntry> stack;
     stack.push_back({root_node.get(), root_aabb});
 
-    geometry::RaycastResult closest_hit{-1.0f, glm::vec3(0.0f)};
+    geometry::RaycastResult closest_hit{.hit = false};
     float closest_t = 1e30f;
 
     while (!stack.empty()) {
@@ -108,9 +108,11 @@ auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
 
                     // Compute hit point and normal
                     glm::vec3 hit_point = ray.origin + result.t * ray.direction;
+                    closest_hit.hit = true;
+                    closest_hit.t = result.t;
+                    closest_hit.inside = result.inside;
                     closest_hit.normal =
                         geometry::compute_aabb_normal(aabb, hit_point);
-                    closest_hit.t = result.t;
                 }
             }
         } else {
@@ -134,12 +136,8 @@ auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
                     // Check if ray could hit this child AABB before closest hit
                     auto child_result =
                         geometry::ray_aabb_intersect(ray, child_aabb);
-                    if (child_result.hit) {
-                        if (child_result.t >= 0.0f &&
-                            child_result.t < closest_t) {
-                            stack.push_back(
-                                {node->children[i].get(), child_aabb});
-                        }
+                    if (child_result.hit && child_result.t < closest_t) {
+                        stack.push_back({node->children[i].get(), child_aabb});
                     }
                 }
             }

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -74,8 +74,7 @@ auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
     geometry::AABB root_aabb = get_bounds();
 
     // Check if ray hits root AABB at all
-    float root_t = 0.0f;
-    if (!geometry::ray_aabb_intersect(ray, root_aabb, &root_t)) {
+    if (!geometry::ray_aabb_intersect(ray, root_aabb).hit) {
         return geometry::RaycastResult{-1.0f, glm::vec3(0.0f)};
     }
 
@@ -101,17 +100,17 @@ auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
         // Check if this is a leaf node (no children)
         if (node->is_leaf) {
             // Raycast against this leaf's AABB
-            float t = 0.0f;
-            if (geometry::ray_aabb_intersect(ray, aabb, &t)) {
+            auto result = geometry::ray_aabb_intersect(ray, aabb);
+            if (result.hit) {
                 // Check if this is the closest hit so far
-                if (t >= 0.0f && t < closest_t) {
-                    closest_t = t;
+                if (result.t >= 0.0f && result.t < closest_t) {
+                    closest_t = result.t;
 
                     // Compute hit point and normal
-                    glm::vec3 hit_point = ray.origin + t * ray.direction;
+                    glm::vec3 hit_point = ray.origin + result.t * ray.direction;
                     closest_hit.normal =
                         geometry::compute_aabb_normal(aabb, hit_point);
-                    closest_hit.t = t;
+                    closest_hit.t = result.t;
                 }
             }
         } else {
@@ -133,10 +132,11 @@ auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
                     child_aabb.max.z = (i & 4) ? aabb.max.z : mid.z;
 
                     // Check if ray could hit this child AABB before closest hit
-                    float child_t = 0.0f;
-                    if (geometry::ray_aabb_intersect(ray, child_aabb,
-                                                     &child_t)) {
-                        if (child_t >= 0.0f && child_t < closest_t) {
+                    auto child_result =
+                        geometry::ray_aabb_intersect(ray, child_aabb);
+                    if (child_result.hit) {
+                        if (child_result.t >= 0.0f &&
+                            child_result.t < closest_t) {
                             stack.push_back(
                                 {node->children[i].get(), child_aabb});
                         }

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -40,11 +40,10 @@ auto Scene::get_chunks() const
 
 auto Scene::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
     // scan through chunks for any intersections
-    float _; // dummy t value
     for (const auto &chunk_pair : this->chunks) {
         Chunk *chunk = chunk_pair.second.get();
         geometry::AABB chunk_bounds = chunk->get_bounds();
-        if (!geometry::ray_aabb_intersect(ray, chunk_bounds, &_))
+        if (!geometry::ray_aabb_intersect(ray, chunk_bounds).hit)
             continue;
 
         // this ray intersects this chunk, let's continue with raycast


### PR DESCRIPTION
This PR will make `ray_aabb_intersect` return a `RayAABBIntersectResult`:

```cpp
typedef struct RayAABBIntersectResult {
    bool hit; // new
    float t;
    bool inside; // new
} RayAABBIntersectResult;
```

It also updates `RaycastResult` with the same new fields. It also fixes an issue with CPU-side raycasting in which the `tFar` value wasn't being returned when casting from inside a node.

## Changes

- Update `geometry::ray_aabb_intersect` and `Chunk::raycast` to return more thorough result structs
- Prevent voxel actions if camera is within a leaf node
- fix: return `tFar` upon raycasting from within an AABB, i.e. the distance to the other side