### PR TITLE
Consume tool UI, add voxel brush options

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -204,29 +204,7 @@ auto Editor::draw_to_surface() -> void {
     ImGui_ImplWGPU_NewFrame();
     ImGui_ImplSDL3_NewFrame();
     ImGui::NewFrame();
-
-    // show basic text
-    ImGui::Begin("Options");
-    if (ImGui::CollapsingHeader("Scene", ImGuiTreeNodeFlags_DefaultOpen |
-                                             ImGuiTreeNodeFlags_Framed)) {
-
-        // Scene Resolution
-        float scale = this->scene.get_chunk_scale();
-        int unit_voxel_depth = glm::log2(512.f / scale);
-        int original_uvd = unit_voxel_depth;
-        ImGui::SliderInt("Resolution", &unit_voxel_depth, 1, 5);
-        ImGui::TextWrapped("This is measured in \"unit voxel depth\", i.e. how "
-                           "many depths of octrees inhabit one unit of space.");
-        if (unit_voxel_depth != original_uvd) {
-            // snap scale to powers of 2
-            float new_scale = 512.f / glm::pow(2.f, unit_voxel_depth);
-            this->scene.set_chunk_scale(new_scale);
-        }
-    }
-
-    ImGui::End();
-
-    // render imgui
+    this->run_gui();
     ImGui::Render();
 
     // Get the next target texture view
@@ -292,6 +270,28 @@ auto Editor::draw_to_surface() -> void {
 
     // Present the surface texture to display it on the window
     this->wgpu.surface.Present();
+}
+
+auto Editor::run_gui() -> void {
+    // Options menu
+    ImGui::Begin("Options");
+    if (ImGui::CollapsingHeader("Scene", ImGuiTreeNodeFlags_DefaultOpen |
+                                             ImGuiTreeNodeFlags_Framed)) {
+
+        // Scene Resolution
+        float scale = this->scene.get_chunk_scale();
+        int unit_voxel_depth = glm::log2(512.f / scale);
+        int original_uvd = unit_voxel_depth;
+        ImGui::SliderInt("Resolution", &unit_voxel_depth, 1, 5);
+        ImGui::TextWrapped("This is measured in \"unit voxel depth\", i.e. how "
+                           "many depths of octrees inhabit one unit of space.");
+        if (unit_voxel_depth != original_uvd) {
+            // snap scale to powers of 2
+            float new_scale = 512.f / glm::pow(2.f, unit_voxel_depth);
+            this->scene.set_chunk_scale(new_scale);
+        }
+    }
+    ImGui::End();
 }
 
 auto Editor::get_surface_configuration(int width, int height)

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -273,10 +273,11 @@ auto Editor::draw_to_surface() -> void {
 }
 
 auto Editor::run_gui() -> void {
-    // Options menu
+
+    // --------- Options menu ---------
+
     ImGui::Begin("Options");
-    if (ImGui::CollapsingHeader("Scene", ImGuiTreeNodeFlags_DefaultOpen |
-                                             ImGuiTreeNodeFlags_Framed)) {
+    if (ImGui::CollapsingHeader("Scene", ImGuiTreeNodeFlags_DefaultOpen)) {
 
         // Scene Resolution
         float scale = this->scene.get_chunk_scale();
@@ -290,6 +291,27 @@ auto Editor::run_gui() -> void {
             float new_scale = 512.f / glm::pow(2.f, unit_voxel_depth);
             this->scene.set_chunk_scale(new_scale);
         }
+    }
+    ImGui::End();
+
+    // --------- Tool menu ---------
+
+    ImGui::Begin("Tools");
+
+    bool is_voxel_brush_selected =
+        this->current_tool == &this->tools.voxel_brush;
+    if (ImGui::RadioButton("Voxel Brush", is_voxel_brush_selected))
+        this->current_tool = &this->tools.voxel_brush;
+    ImGui::TextWrapped("More tools on the way!");
+
+    // spacer
+    ImGui::Dummy(ImVec2(0.0f, 24.0f));
+
+    // tool options section
+    auto tool_name = std::string(this->current_tool->get_tool_name());
+    if (ImGui::CollapsingHeader((tool_name + "###ToolMenu").c_str(),
+                                ImGuiTreeNodeFlags_DefaultOpen)) {
+        this->current_tool->render_ui();
     }
     ImGui::End();
 }

--- a/editor/src/editor.h
+++ b/editor/src/editor.h
@@ -33,6 +33,7 @@ class Editor {
     vxng::scene::Scene scene;
 
     auto draw_to_surface() -> void;
+    auto run_gui() -> void;
     auto get_next_surface_texture_view() -> wgpu::TextureView;
     auto get_surface_configuration(int width, int height)
         -> wgpu::SurfaceConfiguration;

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -62,7 +62,7 @@ auto VoxelBrush::handle_mouse_motion_event(const MouseMotionEventBundle &bundle)
     auto raycast_result = bundle.scene->raycast(mouse_ray);
 
     // set pointer to "cursor" if raycast hit something
-    if (raycast_result.t >= 0) {
+    if (raycast_result.hit) {
         bundle.cursors->set_cursor(Cursors::Variant::POINTER);
     } else {
         bundle.cursors->set_cursor(Cursors::Variant::DEFAULT);

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -1,8 +1,9 @@
 #include "voxel-brush.h"
 
 #include "cursors.h"
+#include "imgui.h"
 
-VoxelBrush::VoxelBrush() {}
+VoxelBrush::VoxelBrush() : depth(9) {}
 
 VoxelBrush::~VoxelBrush() {}
 
@@ -11,7 +12,9 @@ auto VoxelBrush::get_tool_name() -> const char * {
 }
 
 // no ui for this yet
-auto VoxelBrush::render_ui() -> void {}
+auto VoxelBrush::render_ui() -> void {
+    ImGui::SliderInt("Depth", &this->depth, 0, 9);
+}
 
 auto VoxelBrush::handle_mouse_button_event(const MouseButtonEventBundle &bundle)
     -> void {
@@ -42,7 +45,7 @@ auto VoxelBrush::handle_mouse_button_event(const MouseButtonEventBundle &bundle)
         glm::vec3 exterior_target_pos =
             target_pos + raycast_result.normal * 0.00001f;
 
-        bundle.scene->set_voxel_filled(9, exterior_target_pos,
+        bundle.scene->set_voxel_filled(this->depth, exterior_target_pos,
                                        glm::u8vec4(255, 0, 0, 255));
         break;
     }
@@ -50,7 +53,7 @@ auto VoxelBrush::handle_mouse_button_event(const MouseButtonEventBundle &bundle)
         // go inside voxel boundary
         glm::vec3 interior_target_pos =
             target_pos - raycast_result.normal * 0.00001f;
-        bundle.scene->set_voxel_empty(9, interior_target_pos);
+        bundle.scene->set_voxel_empty(this->depth, interior_target_pos);
         break;
     }
     }

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -1,6 +1,7 @@
 #include "voxel-brush.h"
 
 #include "cursors.h"
+
 #include "imgui.h"
 
 VoxelBrush::VoxelBrush() : depth(9) {}

--- a/editor/src/tools/voxel-brush.h
+++ b/editor/src/tools/voxel-brush.h
@@ -16,4 +16,7 @@ class VoxelBrush : public EditorTool {
         -> void override;
     auto handle_keyboard_event(const KeyboardEventBundle &bundle)
         -> void override;
+
+  private:
+    int depth;
 };

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -48,15 +48,12 @@ auto Scene::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
 
         // this ray intersects this chunk, let's continue with raycast
         geometry::RaycastResult chunk_result = chunk->raycast(ray);
-        if (chunk_result.t >= 0) {
+        if (chunk_result.hit)
             return chunk_result;
-        }
     }
 
     // we hit nothing!
-    geometry::RaycastResult result;
-    result.t = -1.f;
-    return result;
+    return geometry::RaycastResult{.hit = false};
 }
 
 auto Scene::set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color)


### PR DESCRIPTION
This PR will make the editor application consume any UI exposed by tools. It will also add a "depth" slider for the simple voxel brush tool, and fix a few bugs.

https://github.com/user-attachments/assets/0df29057-91d3-47c5-9a12-c6b5144981fa


## Changes

- Move GUI calls to new separate method: `Editor::run_gui`
- Add new ImGui window for tool switching/options
  - Includes tool selection menu
  - Calls `EditorTool::render_ui` for tool-specific options
- Add a "depth" parameter on basic voxel brush
- fix: voxel brush cursor update checks
- fix: proper use of chunk raycast results in scene-wide raycast