### PR TITLE
Add titlebar with basic functionality

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -13,9 +13,14 @@
 #include <cstdlib>
 #include <iostream>
 
+#define SCENE_RESOLUTION 512
+#define DEFAULT_SCENE_SCALE 32.f
+
 Editor::Editor()
-    : renderer(), viewport_camera(), scene(512, 32.f), cursors(), tools(),
-      current_tool(&tools.voxel_brush) {};
+    : renderer(), viewport_camera(),
+      scene(std::make_unique<vxng::scene::Scene>(SCENE_RESOLUTION,
+                                                 DEFAULT_SCENE_SCALE)),
+      cursors(), tools(), current_tool(&tools.voxel_brush) {};
 
 auto Editor::init() -> int {
 
@@ -160,8 +165,8 @@ auto Editor::init() -> int {
     this->viewport_camera.set_aspect_ratio(static_cast<float>(width) / height);
     this->renderer.set_active_camera(&this->viewport_camera);
 
-    this->scene.init_webgpu(this->wgpu.device);
-    this->renderer.set_scene(&this->scene);
+    this->scene->init_webgpu(this->wgpu.device);
+    this->renderer.set_scene(this->scene.get());
 
     // initialize imgui
     ImGui_ImplSDL3_InitForOther(this->sdl_window);
@@ -278,8 +283,8 @@ auto Editor::run_gui() -> void {
 
     if (ImGui::BeginMainMenuBar()) {
         if (ImGui::BeginMenu("File")) {
-            if (ImGui::MenuItem("New")) {
-                // TODO: Implement
+            if (ImGui::MenuItem("New (Empty)")) {
+                this->new_empty_scene();
             }
             if (ImGui::MenuItem("Open")) {
                 // TODO: Implement
@@ -306,7 +311,7 @@ auto Editor::run_gui() -> void {
         if (ImGui::CollapsingHeader("Scene", ImGuiTreeNodeFlags_DefaultOpen)) {
 
             // Scene Resolution
-            float scale = this->scene.get_chunk_scale();
+            float scale = this->scene->get_chunk_scale();
             int unit_voxel_depth = glm::log2(512.f / scale);
             int original_uvd = unit_voxel_depth;
             ImGui::SliderInt("Resolution", &unit_voxel_depth, 1, 5);
@@ -316,7 +321,7 @@ auto Editor::run_gui() -> void {
             if (unit_voxel_depth != original_uvd) {
                 // snap scale to powers of 2
                 float new_scale = 512.f / glm::pow(2.f, unit_voxel_depth);
-                this->scene.set_chunk_scale(new_scale);
+                this->scene->set_chunk_scale(new_scale);
             }
         }
         ImGui::End();
@@ -468,10 +473,10 @@ auto Editor::handle_key_down(const SDL_KeyboardEvent &event, bool *quit)
         auto rand_pos =
             (glm::vec3(random_float(), random_float(), random_float()) -
              glm::vec3(0.5f)) *
-            0.99f * this->scene.get_chunk_scale();
+            0.99f * this->scene->get_chunk_scale();
         auto rand_depth = rand() % 3 + 1;
         auto color = glm::u8vec4(255, 255, 255, 255);
-        this->scene.set_voxel_filled(rand_depth, rand_pos, color);
+        this->scene->set_voxel_filled(rand_depth, rand_pos, color);
         break;
     }
 
@@ -480,9 +485,9 @@ auto Editor::handle_key_down(const SDL_KeyboardEvent &event, bool *quit)
         auto rand_pos =
             (glm::vec3(random_float(), random_float(), random_float()) -
              glm::vec3(0.5f)) *
-            0.99f * this->scene.get_chunk_scale();
+            0.99f * this->scene->get_chunk_scale();
         auto rand_depth = rand() % 3 + 1;
-        this->scene.set_voxel_empty(rand_depth, rand_pos);
+        this->scene->set_voxel_empty(rand_depth, rand_pos);
         break;
     }
 
@@ -493,7 +498,7 @@ auto Editor::handle_key_down(const SDL_KeyboardEvent &event, bool *quit)
             EditorTool::KeyboardEventBundle{
                 .event = &event,
                 .mouse_ndc_coords = mouse_ndc_pos,
-                .scene = &this->scene,
+                .scene = this->scene.get(),
                 .camera = &this->viewport_camera,
                 .cursors = &this->cursors,
             });
@@ -507,7 +512,7 @@ auto Editor::handle_key_up(const SDL_KeyboardEvent &event) -> void {
     this->current_tool->handle_keyboard_event(EditorTool::KeyboardEventBundle{
         .event = &event,
         .mouse_ndc_coords = mouse_ndc_pos,
-        .scene = &this->scene,
+        .scene = this->scene.get(),
         .camera = &this->viewport_camera,
         .cursors = &this->cursors,
     });
@@ -535,7 +540,7 @@ auto Editor::handle_mouse_motion(const SDL_MouseMotionEvent &event) -> void {
             EditorTool::MouseMotionEventBundle{
                 .event = &event,
                 .mouse_ndc_coords = mouse_ndc_pos,
-                .scene = &this->scene,
+                .scene = this->scene.get(),
                 .camera = &this->viewport_camera,
                 .cursors = &this->cursors,
             });
@@ -548,7 +553,7 @@ auto Editor::handle_mouse_down(const SDL_MouseButtonEvent &event) -> void {
         EditorTool::MouseButtonEventBundle{
             .event = &event,
             .mouse_ndc_coords = mouse_ndc_pos,
-            .scene = &this->scene,
+            .scene = this->scene.get(),
             .camera = &this->viewport_camera,
             .cursors = &this->cursors,
         });
@@ -560,10 +565,19 @@ auto Editor::handle_mouse_up(const SDL_MouseButtonEvent &event) -> void {
         EditorTool::MouseButtonEventBundle{
             .event = &event,
             .mouse_ndc_coords = mouse_ndc_pos,
-            .scene = &this->scene,
+            .scene = this->scene.get(),
             .camera = &this->viewport_camera,
             .cursors = &this->cursors,
         });
+}
+
+auto Editor::new_empty_scene() -> void {
+    // create new scene object
+    this->scene = std::make_unique<vxng::scene::Scene>(SCENE_RESOLUTION,
+                                                       DEFAULT_SCENE_SCALE);
+    this->scene->init_webgpu(this->wgpu.device);
+
+    this->renderer.set_scene(this->scene.get());
 }
 
 auto Editor::get_mouse_ndc_coords() const -> glm::vec2 {

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -166,6 +166,7 @@ auto Editor::init() -> int {
     this->renderer.set_active_camera(&this->viewport_camera);
 
     this->scene->init_webgpu(this->wgpu.device);
+    this->scene->fill_basic_plane({255, 255, 255, 255});
     this->renderer.set_scene(this->scene.get());
 
     // initialize imgui
@@ -285,6 +286,13 @@ auto Editor::run_gui() -> void {
         if (ImGui::BeginMenu("File")) {
             if (ImGui::MenuItem("New (Empty)")) {
                 this->new_empty_scene();
+            }
+            if (ImGui::BeginMenu("New (Templates)")) {
+                if (ImGui::MenuItem("Flat Plane")) {
+                    this->new_empty_scene();
+                    this->scene->fill_basic_plane({255, 255, 255, 255});
+                }
+                ImGui::EndMenu();
             }
             if (ImGui::MenuItem("Open")) {
                 // TODO: Implement

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -39,7 +39,7 @@ auto Editor::init() -> int {
 
     // create window
     this->sdl_window =
-        SDL_CreateWindow("My Funny Window", 800, 600, SDL_WINDOW_RESIZABLE);
+        SDL_CreateWindow("Voxel Editor", 800, 600, SDL_WINDOW_RESIZABLE);
     if (!sdl_window) {
         SDL_LogError(SDL_LOG_CATEGORY_SYSTEM,
                      "Couldn't create window/renderer: %s", SDL_GetError());

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -274,46 +274,76 @@ auto Editor::draw_to_surface() -> void {
 
 auto Editor::run_gui() -> void {
 
+    // --------- Title/File menu ---------
+
+    if (ImGui::BeginMainMenuBar()) {
+        if (ImGui::BeginMenu("File")) {
+            if (ImGui::MenuItem("New")) {
+                // TODO: Implement
+            }
+            if (ImGui::MenuItem("Open")) {
+                // TODO: Implement
+            }
+            ImGui::EndMenu();
+        }
+
+        if (ImGui::BeginMenu("Panels")) {
+            if (ImGui::MenuItem("Tools", NULL, this->panels.show_tools))
+                this->panels.show_tools = !this->panels.show_tools;
+
+            if (ImGui::MenuItem("Options", NULL, this->panels.show_options))
+                this->panels.show_options = !this->panels.show_options;
+
+            ImGui::EndMenu();
+        }
+        ImGui::EndMainMenuBar();
+    }
+
     // --------- Options menu ---------
 
-    ImGui::Begin("Options");
-    if (ImGui::CollapsingHeader("Scene", ImGuiTreeNodeFlags_DefaultOpen)) {
+    if (this->panels.show_options) {
+        ImGui::Begin("Options");
+        if (ImGui::CollapsingHeader("Scene", ImGuiTreeNodeFlags_DefaultOpen)) {
 
-        // Scene Resolution
-        float scale = this->scene.get_chunk_scale();
-        int unit_voxel_depth = glm::log2(512.f / scale);
-        int original_uvd = unit_voxel_depth;
-        ImGui::SliderInt("Resolution", &unit_voxel_depth, 1, 5);
-        ImGui::TextWrapped("This is measured in \"unit voxel depth\", i.e. how "
-                           "many depths of octrees inhabit one unit of space.");
-        if (unit_voxel_depth != original_uvd) {
-            // snap scale to powers of 2
-            float new_scale = 512.f / glm::pow(2.f, unit_voxel_depth);
-            this->scene.set_chunk_scale(new_scale);
+            // Scene Resolution
+            float scale = this->scene.get_chunk_scale();
+            int unit_voxel_depth = glm::log2(512.f / scale);
+            int original_uvd = unit_voxel_depth;
+            ImGui::SliderInt("Resolution", &unit_voxel_depth, 1, 5);
+            ImGui::TextWrapped(
+                "This is measured in \"unit voxel depth\", i.e. how "
+                "many depths of octrees inhabit one unit of space.");
+            if (unit_voxel_depth != original_uvd) {
+                // snap scale to powers of 2
+                float new_scale = 512.f / glm::pow(2.f, unit_voxel_depth);
+                this->scene.set_chunk_scale(new_scale);
+            }
         }
+        ImGui::End();
     }
-    ImGui::End();
 
     // --------- Tool menu ---------
 
-    ImGui::Begin("Tools");
+    if (this->panels.show_tools) {
+        ImGui::Begin("Tools");
 
-    bool is_voxel_brush_selected =
-        this->current_tool == &this->tools.voxel_brush;
-    if (ImGui::RadioButton("Voxel Brush", is_voxel_brush_selected))
-        this->current_tool = &this->tools.voxel_brush;
-    ImGui::TextWrapped("More tools on the way!");
+        bool is_voxel_brush_selected =
+            this->current_tool == &this->tools.voxel_brush;
+        if (ImGui::RadioButton("Voxel Brush", is_voxel_brush_selected))
+            this->current_tool = &this->tools.voxel_brush;
+        ImGui::TextWrapped("More tools on the way!");
 
-    // spacer
-    ImGui::Dummy(ImVec2(0.0f, 24.0f));
+        // spacer
+        ImGui::Dummy(ImVec2(0.0f, 24.0f));
 
-    // tool options section
-    auto tool_name = std::string(this->current_tool->get_tool_name());
-    if (ImGui::CollapsingHeader((tool_name + "###ToolMenu").c_str(),
-                                ImGuiTreeNodeFlags_DefaultOpen)) {
-        this->current_tool->render_ui();
+        // tool options section
+        auto tool_name = std::string(this->current_tool->get_tool_name());
+        if (ImGui::CollapsingHeader((tool_name + "###ToolMenu").c_str(),
+                                    ImGuiTreeNodeFlags_DefaultOpen)) {
+            this->current_tool->render_ui();
+        }
+        ImGui::End();
     }
-    ImGui::End();
 }
 
 auto Editor::get_surface_configuration(int width, int height)

--- a/editor/src/editor.h
+++ b/editor/src/editor.h
@@ -46,17 +46,17 @@ class Editor {
     auto handle_mouse_down(const SDL_MouseButtonEvent &event) -> void;
     auto handle_mouse_up(const SDL_MouseButtonEvent &event) -> void;
 
-    struct {
-        bool is_active;
-        glm::vec3 target, normal;
-    } pointer;
-
     Cursors cursors;
 
     struct {
         VoxelBrush voxel_brush;
     } tools;
     EditorTool *current_tool;
+
+    struct {
+        bool show_tools = true;
+        bool show_options = true;
+    } panels;
 
     auto get_mouse_ndc_coords() const -> glm::vec2;
 };

--- a/editor/src/editor.h
+++ b/editor/src/editor.h
@@ -4,11 +4,12 @@
 #include "tool.h"
 #include "tools/tools.h"
 
-#include <vxng/vxng.h>
-
 #include <SDL3/SDL.h>
 #include <imgui.h>
+#include <vxng/vxng.h>
 #include <webgpu/webgpu_cpp.h>
+
+#include <memory>
 
 class Editor {
   public:
@@ -30,7 +31,7 @@ class Editor {
 
     vxng::Renderer renderer;
     vxng::camera::OrbitCamera viewport_camera;
-    vxng::scene::Scene scene;
+    std::unique_ptr<vxng::scene::Scene> scene;
 
     auto draw_to_surface() -> void;
     auto run_gui() -> void;
@@ -57,6 +58,9 @@ class Editor {
         bool show_tools = true;
         bool show_options = true;
     } panels;
+
+    // menu options
+    auto new_empty_scene() -> void;
 
     auto get_mouse_ndc_coords() const -> glm::vec2;
 };

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "glm/fwd.hpp"
 #include "vxng/geometry.h"
 
 #include <glm/glm.hpp>
@@ -41,6 +42,13 @@ class Scene {
     /** Internal method, for renderer to render chunks */
     auto get_chunks() const
         -> const std::unordered_map<glm::ivec3, std::unique_ptr<Chunk>> &;
+
+    // --------- Scene setup helpers ---------
+
+    /**
+     * Fills bottom 4 octants of root chunk with the given color.
+     */
+    auto fill_basic_plane(glm::u8vec4 color) -> void;
 
   private:
     float chunk_scale;

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -2,6 +2,7 @@
 
 #include "chunk.h"
 
+#include <limits>
 #include <memory>
 #include <stdexcept>
 
@@ -50,6 +51,10 @@ auto Scene::fill_basic_plane(glm::u8vec4 color) -> void {
 
 auto Scene::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
     // scan through chunks for any intersections
+    geometry::RaycastResult closest_hit;
+    closest_hit.hit = false;
+    closest_hit.t = std::numeric_limits<float>::max();
+
     for (const auto &chunk_pair : this->chunks) {
         Chunk *chunk = chunk_pair.second.get();
         geometry::AABB chunk_bounds = chunk->get_bounds();
@@ -58,12 +63,11 @@ auto Scene::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
 
         // this ray intersects this chunk, let's continue with raycast
         geometry::RaycastResult chunk_result = chunk->raycast(ray);
-        if (chunk_result.hit)
-            return chunk_result;
+        if (chunk_result.hit && chunk_result.t < closest_hit.t)
+            closest_hit = chunk_result;
     }
 
-    // we hit nothing!
-    return geometry::RaycastResult{.hit = false};
+    return closest_hit;
 }
 
 auto Scene::set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color)

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -38,6 +38,16 @@ auto Scene::get_chunks() const
     return this->chunks;
 }
 
+auto Scene::fill_basic_plane(glm::u8vec4 color) -> void {
+    // set 4 base plates filled
+    float delta = this->chunk_scale / (float)this->chunk_resolution * 0.5f;
+
+    this->set_voxel_filled(1, {delta, -delta, delta}, color);
+    this->set_voxel_filled(1, {-delta, -delta, delta}, color);
+    this->set_voxel_filled(1, {-delta, -delta, -delta}, color);
+    this->set_voxel_filled(1, {delta, -delta, -delta}, color);
+}
+
 auto Scene::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
     // scan through chunks for any intersections
     for (const auto &chunk_pair : this->chunks) {


### PR DESCRIPTION
This PR will add a titlebar, which includes basic utilities.

<img width="236" height="142" alt="image" src="https://github.com/user-attachments/assets/0f816109-b0fe-410e-bcb2-04be7a835c69" />


## Changes

- Add ImGui titlebar
  - "File" menu
    - "New (empty)" clears scene
    - "New (templates)" - has "flat plane" template for now
    - "Open" not implemented
  - "Panels" menu, with a toggle for each draggable panel
- Add "flat plane" scene generator method
- Turn `Editor.scene` into a unique pointer for easier scene resets/manipulation
- fix: multi-chunk scene raycast traversal logic
- patch: extract default scene resolution and scale into constants
- patch: make window title more serious