### PR TITLE
Add color palette

### DIFF
--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${PROJECT_NAME}
         src/tools/voxel-brush.cpp
         src/cursors.cpp
         src/editor.cpp
+        src/palette.cpp
         src/main.cpp
         src/tool.cpp
 )

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -342,19 +342,21 @@ auto Editor::run_gui() -> void {
         ImGui::Begin("Tools");
 
         // palette
-        ImGui::Text("Palette");
+        ImGui::SeparatorText("Palette");
         palette.run_imgui();
         ImGui::Spacing();
 
+        ImGui::Dummy(ImVec2(0.0f, 16.0f));
+
         // tool selection
+        ImGui::SeparatorText("Tool Selection");
         if (ImGui::RadioButton("Voxel Brush",
                                this->current_tool == &this->tools.voxel_brush))
             this->current_tool = &this->tools.voxel_brush;
 
         ImGui::TextWrapped("More tools on the way!");
 
-        // spacer
-        ImGui::Dummy(ImVec2(0.0f, 24.0f));
+        ImGui::Dummy(ImVec2(0.0f, 8.0f));
 
         // tool options section
         auto tool_name = std::string(this->current_tool->get_tool_name());

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -1,7 +1,5 @@
 #include "editor.h"
 
-#include "cursors.h"
-
 #include <SDL3/SDL.h>
 #include <imgui.h>
 #include <imgui_impl_sdl3.h>
@@ -21,7 +19,9 @@ Editor::Editor()
     : renderer(), viewport_camera(),
       scene(std::make_unique<vxng::scene::Scene>(SCENE_RESOLUTION,
                                                  DEFAULT_SCENE_SCALE)),
-      cursors(), tools(), current_tool(&tools.voxel_brush) {};
+      cursors(), tools(), current_tool(&tools.voxel_brush), palette() {
+    palette.init_default_colors();
+};
 
 auto Editor::init() -> int {
 
@@ -341,10 +341,16 @@ auto Editor::run_gui() -> void {
     if (this->panels.show_tools) {
         ImGui::Begin("Tools");
 
-        bool is_voxel_brush_selected =
-            this->current_tool == &this->tools.voxel_brush;
-        if (ImGui::RadioButton("Voxel Brush", is_voxel_brush_selected))
+        // palette
+        ImGui::Text("Palette");
+        palette.run_imgui();
+        ImGui::Spacing();
+
+        // tool selection
+        if (ImGui::RadioButton("Voxel Brush",
+                               this->current_tool == &this->tools.voxel_brush))
             this->current_tool = &this->tools.voxel_brush;
+
         ImGui::TextWrapped("More tools on the way!");
 
         // spacer
@@ -614,5 +620,6 @@ auto Editor::make_event_bundle() -> EditorTool::EventBundle {
         .scene = this->scene.get(),
         .camera = &this->viewport_camera,
         .cursors = &this->cursors,
+        .current_color = this->palette.get_current_color(),
     };
 }

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -548,28 +548,14 @@ auto Editor::handle_key_down(const SDL_KeyboardEvent &event, bool *quit)
 
     default: {
         // pass off to current tool
-        glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
-        this->current_tool->handle_keyboard_event(
-            event, EditorTool::EventBundle{
-                       .mouse_ndc_coords = mouse_ndc_pos,
-                       .scene = this->scene.get(),
-                       .camera = &this->viewport_camera,
-                       .cursors = &this->cursors,
-                   });
+        this->current_tool->handle_keyboard_event(event, make_event_bundle());
     }
     }
 }
 
 auto Editor::handle_key_up(const SDL_KeyboardEvent &event) -> void {
     // pass off to current tool
-    glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
-    this->current_tool->handle_keyboard_event(
-        event, EditorTool::EventBundle{
-                   .mouse_ndc_coords = mouse_ndc_pos,
-                   .scene = this->scene.get(),
-                   .camera = &this->viewport_camera,
-                   .cursors = &this->cursors,
-               });
+    this->current_tool->handle_keyboard_event(event, make_event_bundle());
 }
 
 auto Editor::handle_mouse_motion(const SDL_MouseMotionEvent &event) -> void {
@@ -589,37 +575,17 @@ auto Editor::handle_mouse_motion(const SDL_MouseMotionEvent &event) -> void {
         }
     } else {
         // no mod held, pass off to current tool
-        glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
-        this->current_tool->handle_mouse_motion_event(
-            event, EditorTool::EventBundle{
-                       .mouse_ndc_coords = mouse_ndc_pos,
-                       .scene = this->scene.get(),
-                       .camera = &this->viewport_camera,
-                       .cursors = &this->cursors,
-                   });
+        this->current_tool->handle_mouse_motion_event(event,
+                                                      make_event_bundle());
     }
 }
 
 auto Editor::handle_mouse_down(const SDL_MouseButtonEvent &event) -> void {
-    glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
-    this->current_tool->handle_mouse_button_event(
-        event, EditorTool::EventBundle{
-                   .mouse_ndc_coords = mouse_ndc_pos,
-                   .scene = this->scene.get(),
-                   .camera = &this->viewport_camera,
-                   .cursors = &this->cursors,
-               });
+    this->current_tool->handle_mouse_button_event(event, make_event_bundle());
 }
 
 auto Editor::handle_mouse_up(const SDL_MouseButtonEvent &event) -> void {
-    glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
-    this->current_tool->handle_mouse_button_event(
-        event, EditorTool::EventBundle{
-                   .mouse_ndc_coords = mouse_ndc_pos,
-                   .scene = this->scene.get(),
-                   .camera = &this->viewport_camera,
-                   .cursors = &this->cursors,
-               });
+    this->current_tool->handle_mouse_button_event(event, make_event_bundle());
 }
 
 auto Editor::new_empty_scene() -> void {
@@ -631,7 +597,7 @@ auto Editor::new_empty_scene() -> void {
     this->renderer.set_scene(this->scene.get());
 }
 
-auto Editor::get_mouse_ndc_coords() const -> glm::vec2 {
+auto Editor::make_event_bundle() -> EditorTool::EventBundle {
     glm::vec2 screen_pos;
     SDL_GetMouseState(&screen_pos.x, &screen_pos.y);
     glm::ivec2 screen_size;
@@ -641,5 +607,12 @@ auto Editor::get_mouse_ndc_coords() const -> glm::vec2 {
     screen_pos /= screen_size;
 
     // flip y and scale both to [-1, 1]
-    return (screen_pos - glm::vec2(0.5)) * glm::vec2(2.f, -2.f);
+    auto mouse_ndc_pos = (screen_pos - glm::vec2(0.5)) * glm::vec2(2.f, -2.f);
+
+    return EditorTool::EventBundle{
+        .mouse_ndc_coords = mouse_ndc_pos,
+        .scene = this->scene.get(),
+        .camera = &this->viewport_camera,
+        .cursors = &this->cursors,
+    };
 }

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -550,13 +550,12 @@ auto Editor::handle_key_down(const SDL_KeyboardEvent &event, bool *quit)
         // pass off to current tool
         glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
         this->current_tool->handle_keyboard_event(
-            EditorTool::KeyboardEventBundle{
-                .event = &event,
-                .mouse_ndc_coords = mouse_ndc_pos,
-                .scene = this->scene.get(),
-                .camera = &this->viewport_camera,
-                .cursors = &this->cursors,
-            });
+            event, EditorTool::EventBundle{
+                       .mouse_ndc_coords = mouse_ndc_pos,
+                       .scene = this->scene.get(),
+                       .camera = &this->viewport_camera,
+                       .cursors = &this->cursors,
+                   });
     }
     }
 }
@@ -564,13 +563,13 @@ auto Editor::handle_key_down(const SDL_KeyboardEvent &event, bool *quit)
 auto Editor::handle_key_up(const SDL_KeyboardEvent &event) -> void {
     // pass off to current tool
     glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
-    this->current_tool->handle_keyboard_event(EditorTool::KeyboardEventBundle{
-        .event = &event,
-        .mouse_ndc_coords = mouse_ndc_pos,
-        .scene = this->scene.get(),
-        .camera = &this->viewport_camera,
-        .cursors = &this->cursors,
-    });
+    this->current_tool->handle_keyboard_event(
+        event, EditorTool::EventBundle{
+                   .mouse_ndc_coords = mouse_ndc_pos,
+                   .scene = this->scene.get(),
+                   .camera = &this->viewport_camera,
+                   .cursors = &this->cursors,
+               });
 }
 
 auto Editor::handle_mouse_motion(const SDL_MouseMotionEvent &event) -> void {
@@ -592,38 +591,35 @@ auto Editor::handle_mouse_motion(const SDL_MouseMotionEvent &event) -> void {
         // no mod held, pass off to current tool
         glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
         this->current_tool->handle_mouse_motion_event(
-            EditorTool::MouseMotionEventBundle{
-                .event = &event,
-                .mouse_ndc_coords = mouse_ndc_pos,
-                .scene = this->scene.get(),
-                .camera = &this->viewport_camera,
-                .cursors = &this->cursors,
-            });
+            event, EditorTool::EventBundle{
+                       .mouse_ndc_coords = mouse_ndc_pos,
+                       .scene = this->scene.get(),
+                       .camera = &this->viewport_camera,
+                       .cursors = &this->cursors,
+                   });
     }
 }
 
 auto Editor::handle_mouse_down(const SDL_MouseButtonEvent &event) -> void {
     glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
     this->current_tool->handle_mouse_button_event(
-        EditorTool::MouseButtonEventBundle{
-            .event = &event,
-            .mouse_ndc_coords = mouse_ndc_pos,
-            .scene = this->scene.get(),
-            .camera = &this->viewport_camera,
-            .cursors = &this->cursors,
-        });
+        event, EditorTool::EventBundle{
+                   .mouse_ndc_coords = mouse_ndc_pos,
+                   .scene = this->scene.get(),
+                   .camera = &this->viewport_camera,
+                   .cursors = &this->cursors,
+               });
 }
 
 auto Editor::handle_mouse_up(const SDL_MouseButtonEvent &event) -> void {
     glm::vec2 mouse_ndc_pos = get_mouse_ndc_coords();
     this->current_tool->handle_mouse_button_event(
-        EditorTool::MouseButtonEventBundle{
-            .event = &event,
-            .mouse_ndc_coords = mouse_ndc_pos,
-            .scene = this->scene.get(),
-            .camera = &this->viewport_camera,
-            .cursors = &this->cursors,
-        });
+        event, EditorTool::EventBundle{
+                   .mouse_ndc_coords = mouse_ndc_pos,
+                   .scene = this->scene.get(),
+                   .camera = &this->viewport_camera,
+                   .cursors = &this->cursors,
+               });
 }
 
 auto Editor::new_empty_scene() -> void {

--- a/editor/src/editor.h
+++ b/editor/src/editor.h
@@ -67,5 +67,5 @@ class Editor {
     // menu options
     auto new_empty_scene() -> void;
 
-    auto get_mouse_ndc_coords() const -> glm::vec2;
+    auto make_event_bundle() -> EditorTool::EventBundle;
 };

--- a/editor/src/editor.h
+++ b/editor/src/editor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "cursors.h"
+#include "palette.h"
 #include "tool.h"
 #include "tools/tools.h"
 
@@ -58,6 +59,7 @@ class Editor {
         VoxelBrush voxel_brush;
     } tools;
     EditorTool *current_tool;
+    Palette palette;
 
     struct {
         bool show_tools = true;

--- a/editor/src/palette.cpp
+++ b/editor/src/palette.cpp
@@ -2,7 +2,7 @@
 
 #include <imgui.h>
 
-Palette::Palette() : colors(), current_color_idx(0) {}
+Palette::Palette() : colors(), current_color_idx(0), picker_color(255) {}
 Palette::~Palette() {}
 
 auto Palette::init_default_colors() -> void {
@@ -60,8 +60,20 @@ auto Palette::run_imgui() -> void {
                     : default_flags | ImGuiColorEditFlags_NoBorder,
                 ImVec2(16, 16))) {
             set_current_color(i);
+            this->picker_color = glm::vec4(glm::vec3(color) / 255.f, 1.0);
         }
 
         ImGui::PopID();
+    }
+
+    ImGui::Spacing();
+    if (ImGui::CollapsingHeader("Custom Colors")) {
+        ImGui::ColorPicker4("##color_picker", &this->picker_color[0],
+                            ImGuiColorEditFlags_NoAlpha);
+        if (ImGui::Button("+ Add to palette")) {
+            int new_color_idx = add_color(
+                glm::u8vec4(glm::vec3(this->picker_color) * 255.f, 255));
+            this->set_current_color(new_color_idx);
+        }
     }
 }

--- a/editor/src/palette.cpp
+++ b/editor/src/palette.cpp
@@ -2,7 +2,7 @@
 
 #include <imgui.h>
 
-Palette::Palette() : colors(), current_color_idx(0), picker_color(255) {}
+Palette::Palette() : colors(), current_color_idx(0), picker_color(1.f) {}
 Palette::~Palette() {}
 
 auto Palette::init_default_colors() -> void {

--- a/editor/src/palette.cpp
+++ b/editor/src/palette.cpp
@@ -1,0 +1,41 @@
+#include "palette.h"
+
+Palette::Palette() : colors(), current_color_idx(0) {}
+Palette::~Palette() {}
+
+auto Palette::init_default_colors() -> void {
+    this->colors.clear();
+    this->colors.reserve(6 * 6 * 6);
+    for (int r = 0; r < 6; ++r) {
+        for (int g = 0; g < 6; ++g) {
+            for (int b = 0; b < 6; ++b) {
+                this->colors.push_back(glm::u8vec4(r, g, b, 5) * (uint8_t)51);
+            }
+        }
+    }
+}
+
+auto Palette::add_color(const glm::u8vec4 &color) -> int {
+    auto it = std::find(this->colors.begin(), this->colors.end(), color);
+    if (it != this->colors.end())
+        return std::distance(this->colors.begin(), it);
+
+    this->colors.push_back(color);
+    return this->colors.size() - 1;
+}
+
+auto Palette::get_current_color() const -> glm::u8vec4 {
+    return this->colors[this->current_color_idx];
+}
+
+auto Palette::set_current_color(int index) -> glm::u8vec4 {
+    this->current_color_idx = index;
+    return this->colors[this->current_color_idx];
+}
+
+auto Palette::remove_color(int index) -> void {
+    this->colors.erase(std::next(this->colors.begin(), index));
+
+    if (this->current_color_idx >= index && this->current_color_idx > 0)
+        --this->current_color_idx;
+}

--- a/editor/src/palette.cpp
+++ b/editor/src/palette.cpp
@@ -1,15 +1,17 @@
 #include "palette.h"
 
+#include <imgui.h>
+
 Palette::Palette() : colors(), current_color_idx(0) {}
 Palette::~Palette() {}
 
 auto Palette::init_default_colors() -> void {
     this->colors.clear();
-    this->colors.reserve(6 * 6 * 6);
-    for (int r = 0; r < 6; ++r) {
-        for (int g = 0; g < 6; ++g) {
-            for (int b = 0; b < 6; ++b) {
-                this->colors.push_back(glm::u8vec4(r, g, b, 5) * (uint8_t)51);
+    this->colors.reserve(4 * 4 * 4);
+    for (int r = 0; r < 4; ++r) {
+        for (int g = 0; g < 4; ++g) {
+            for (int b = 0; b < 4; ++b) {
+                this->colors.push_back(glm::u8vec4(r, g, b, 3) * (uint8_t)85);
             }
         }
     }
@@ -38,4 +40,28 @@ auto Palette::remove_color(int index) -> void {
 
     if (this->current_color_idx >= index && this->current_color_idx > 0)
         --this->current_color_idx;
+}
+
+auto Palette::run_imgui() -> void {
+    auto default_flags =
+        ImGuiColorEditFlags_NoPicker | ImGuiColorEditFlags_NoTooltip;
+    for (int i = 0; i < this->colors.size(); ++i) {
+        ImGui::PushID(i);
+
+        if ((i % 8) != 0)
+            ImGui::SameLine(0.0f, ImGui::GetStyle().ItemSpacing.y);
+
+        auto &color = this->colors[i];
+        if (ImGui::ColorButton(
+                "##palette",
+                ImVec4(color.r / 255.f, color.g / 255.f, color.b / 255.f, 1.f),
+                current_color_idx == i
+                    ? default_flags
+                    : default_flags | ImGuiColorEditFlags_NoBorder,
+                ImVec2(16, 16))) {
+            set_current_color(i);
+        }
+
+        ImGui::PopID();
+    }
 }

--- a/editor/src/palette.h
+++ b/editor/src/palette.h
@@ -11,6 +11,8 @@ class Palette {
 
     auto init_default_colors() -> void;
 
+    /** Returns new index of the color. If the color already exists, does
+     * nothing but still returns index. */
     auto add_color(const glm::u8vec4 &color) -> int;
     auto get_current_color() const -> glm::u8vec4;
     auto set_current_color(int index) -> glm::u8vec4;

--- a/editor/src/palette.h
+++ b/editor/src/palette.h
@@ -23,4 +23,6 @@ class Palette {
   private:
     std::vector<glm::u8vec4> colors;
     int current_color_idx;
+
+    glm::vec4 picker_color;
 };

--- a/editor/src/palette.h
+++ b/editor/src/palette.h
@@ -18,6 +18,8 @@ class Palette {
     auto set_current_color(int index) -> glm::u8vec4;
     auto remove_color(int index) -> void;
 
+    auto run_imgui() -> void;
+
   private:
     std::vector<glm::u8vec4> colors;
     int current_color_idx;

--- a/editor/src/palette.h
+++ b/editor/src/palette.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include <vector>
+
+class Palette {
+  public:
+    Palette();
+    ~Palette();
+
+    auto init_default_colors() -> void;
+
+    auto add_color(const glm::u8vec4 &color) -> int;
+    auto get_current_color() const -> glm::u8vec4;
+    auto set_current_color(int index) -> glm::u8vec4;
+    auto remove_color(int index) -> void;
+
+  private:
+    std::vector<glm::u8vec4> colors;
+    int current_color_idx;
+};

--- a/editor/src/tool.h
+++ b/editor/src/tool.h
@@ -22,6 +22,7 @@ class EditorTool {
         vxng::scene::Scene *scene;
         vxng::camera::Camera *camera;
         Cursors *cursors;
+        glm::u8vec4 current_color;
     } EventBundle;
 
     virtual auto handle_mouse_button_event(const SDL_MouseButtonEvent &event,

--- a/editor/src/tool.h
+++ b/editor/src/tool.h
@@ -17,34 +17,19 @@ class EditorTool {
     virtual auto get_tool_name() -> const char * = 0;
     virtual auto render_ui() -> void = 0;
 
-    typedef struct KeyboardEventBundle {
-        const SDL_KeyboardEvent *event;
+    typedef struct EventBundle {
         glm::vec2 mouse_ndc_coords;
         vxng::scene::Scene *scene;
         vxng::camera::Camera *camera;
         Cursors *cursors;
-    } KeyboardEventBundle;
+    } EventBundle;
 
-    typedef struct MouseButtonEventBundle {
-        const SDL_MouseButtonEvent *event;
-        glm::vec2 mouse_ndc_coords;
-        vxng::scene::Scene *scene;
-        vxng::camera::Camera *camera;
-        Cursors *cursors;
-    } MouseButtonEventBundle;
-
-    typedef struct MouseMotionEventBundle {
-        const SDL_MouseMotionEvent *event;
-        glm::vec2 mouse_ndc_coords;
-        vxng::scene::Scene *scene;
-        vxng::camera::Camera *camera;
-        Cursors *cursors;
-    } MouseMotionEventBundle;
-
-    virtual auto handle_mouse_button_event(const MouseButtonEventBundle &bundle)
+    virtual auto handle_mouse_button_event(const SDL_MouseButtonEvent &event,
+                                           const EventBundle &bundle)
         -> void = 0;
-    virtual auto handle_mouse_motion_event(const MouseMotionEventBundle &bundle)
+    virtual auto handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
+                                           const EventBundle &bundle)
         -> void = 0;
-    virtual auto handle_keyboard_event(const KeyboardEventBundle &bundle)
-        -> void = 0;
+    virtual auto handle_keyboard_event(const SDL_KeyboardEvent &event,
+                                       const EventBundle &bundle) -> void = 0;
 };

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -48,7 +48,7 @@ auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
             target_pos + raycast_result.normal * 0.00001f;
 
         bundle.scene->set_voxel_filled(this->depth, exterior_target_pos,
-                                       glm::u8vec4(255, 0, 0, 255));
+                                       bundle.current_color);
         break;
     }
     case SDL_BUTTON_RIGHT: {

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -1,5 +1,6 @@
 #include "voxel-brush.h"
 
+#include "SDL3/SDL_events.h"
 #include "cursors.h"
 
 #include "imgui.h"
@@ -17,10 +18,10 @@ auto VoxelBrush::render_ui() -> void {
     ImGui::SliderInt("Depth", &this->depth, 0, 9);
 }
 
-auto VoxelBrush::handle_mouse_button_event(const MouseButtonEventBundle &bundle)
-    -> void {
+auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
+                                           const EventBundle &bundle) -> void {
     // we don't care about mouse up
-    if (!bundle.event->down)
+    if (!event.down)
         return;
 
     // don't do anything if any mods are held
@@ -40,7 +41,7 @@ auto VoxelBrush::handle_mouse_button_event(const MouseButtonEventBundle &bundle)
         mouse_ray.origin + raycast_result.t * mouse_ray.direction;
 
     // set voxel filled!
-    switch (bundle.event->button) {
+    switch (event.button) {
     case SDL_BUTTON_LEFT: {
         // go outside of voxel boundary
         glm::vec3 exterior_target_pos =
@@ -60,8 +61,8 @@ auto VoxelBrush::handle_mouse_button_event(const MouseButtonEventBundle &bundle)
     }
 }
 
-auto VoxelBrush::handle_mouse_motion_event(const MouseMotionEventBundle &bundle)
-    -> void {
+auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
+                                           const EventBundle &bundle) -> void {
     auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
     auto raycast_result = bundle.scene->raycast(mouse_ray);
 
@@ -73,5 +74,5 @@ auto VoxelBrush::handle_mouse_motion_event(const MouseMotionEventBundle &bundle)
     }
 }
 
-auto VoxelBrush::handle_keyboard_event(const KeyboardEventBundle &bundle)
-    -> void {}
+auto VoxelBrush::handle_keyboard_event(const SDL_KeyboardEvent &event,
+                                       const EventBundle &bundle) -> void {}

--- a/editor/src/tools/voxel-brush.h
+++ b/editor/src/tools/voxel-brush.h
@@ -10,12 +10,12 @@ class VoxelBrush : public EditorTool {
     auto get_tool_name() -> const char * override;
     auto render_ui() -> void override;
 
-    auto handle_mouse_button_event(const MouseButtonEventBundle &bundle)
-        -> void override;
-    auto handle_mouse_motion_event(const MouseMotionEventBundle &bundle)
-        -> void override;
-    auto handle_keyboard_event(const KeyboardEventBundle &bundle)
-        -> void override;
+    auto handle_mouse_button_event(const SDL_MouseButtonEvent &event,
+                                   const EventBundle &bundle) -> void override;
+    auto handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
+                                   const EventBundle &bundle) -> void override;
+    auto handle_keyboard_event(const SDL_KeyboardEvent &event,
+                               const EventBundle &bundle) -> void override;
 
   private:
     int depth;


### PR DESCRIPTION
This PR will add a color palette to the editor.

## Changes

- Add `Palette` class which handles color management and selection
- Consume `Palette` in `Editor` and pass its custom color to tools
- Consume a `current_color` in `EditorTool::EventBundle` structs
- refactor: simplify bundle types to single `EventBundle` struct for tools


<img width="912" height="744" alt="Screenshot 2026-04-23 at 3 02 50 PM" src="https://github.com/user-attachments/assets/2c7e6481-0d17-4df0-837c-9b4812f3d5fe" />
