### PR TITLE
Add click and drag for brush

### DIFF
--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -3,7 +3,9 @@
 #include <imgui.h>
 #include <vxng/geometry.h>
 
-VoxelBrush::VoxelBrush() : depth(9), plane_normal() {}
+VoxelBrush::VoxelBrush()
+    : current_mode(Mode::AXIS_ALIGNED), depth(9), flow_density(5.f),
+      plane_normal(), last_mouse_ndc_coords() {}
 
 VoxelBrush::~VoxelBrush() {}
 
@@ -13,7 +15,15 @@ auto VoxelBrush::get_tool_name() -> const char * {
 
 // no ui for this yet
 auto VoxelBrush::render_ui() -> void {
+    if (ImGui::RadioButton("Axis aligned",
+                           this->current_mode == Mode::AXIS_ALIGNED))
+        this->current_mode = Mode::AXIS_ALIGNED;
+    if (ImGui::RadioButton("Camera plane",
+                           this->current_mode == Mode::CAMERA_PLANE))
+        this->current_mode = Mode::CAMERA_PLANE;
+
     ImGui::SliderInt("Depth", &this->depth, 0, 9);
+    ImGui::SliderFloat("Flow Density", &this->flow_density, 0.f, 20.f);
 }
 
 auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
@@ -38,6 +48,9 @@ auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
     glm::vec3 target_pos =
         mouse_ray.origin + raycast_result.t * mouse_ray.direction;
 
+    glm::vec3 plane_normal = this->current_mode == Mode::AXIS_ALIGNED
+                                 ? raycast_result.normal
+                                 : bundle.camera->get_forward();
     // set voxel filled!
     switch (event.button) {
     case SDL_BUTTON_LEFT: {
@@ -49,7 +62,7 @@ auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
                                        bundle.current_color);
         this->plane_normal = vxng::geometry::Ray{
             .origin = exterior_target_pos,
-            .direction = raycast_result.normal,
+            .direction = plane_normal,
         };
         break;
     }
@@ -59,8 +72,8 @@ auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
             target_pos - raycast_result.normal * 0.00001f;
         bundle.scene->set_voxel_empty(this->depth, interior_target_pos);
         this->plane_normal = vxng::geometry::Ray{
-            .origin = target_pos,
-            .direction = raycast_result.normal,
+            .origin = interior_target_pos,
+            .direction = plane_normal,
         };
         break;
     }
@@ -81,35 +94,50 @@ auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
 
     // do dragging logic
     if (event.state & (SDL_BUTTON_LMASK | SDL_BUTTON_RMASK)) {
-        auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
+        float mouse_move_distance =
+            ((bundle.mouse_ndc_coords - this->last_mouse_ndc_coords) *
+             glm::vec2(bundle.camera->get_aspect_ratio(), 1.f))
+                .length();
 
-        // project mouse ray onto plane defined by plane_normal
-        float denom =
-            glm::dot(this->plane_normal.direction, mouse_ray.direction);
-        if (std::abs(denom) > 1e-6f) {
-            float t = glm::dot(this->plane_normal.origin - mouse_ray.origin,
-                               this->plane_normal.direction) /
-                      denom;
-            if (t >= 0.0f) {
-                // place voxel if hit
-                glm::vec3 intersection =
-                    mouse_ray.origin + t * mouse_ray.direction;
-                if (event.state & SDL_BUTTON_LEFT) {
-                    // add voxels
-                    glm::vec3 exterior_target_pos =
-                        intersection + this->plane_normal.direction * 0.00001f;
-                    bundle.scene->set_voxel_filled(
-                        this->depth, exterior_target_pos, bundle.current_color);
-                } else {
-                    // remove voxels
-                    glm::vec3 interior_target_pos =
-                        intersection - this->plane_normal.direction * 0.00001f;
-                    bundle.scene->set_voxel_empty(this->depth,
-                                                  interior_target_pos);
+        int flow_step_count =
+            glm::ceil(mouse_move_distance * this->flow_density);
+
+        for (int step = 1; step <= flow_step_count; ++step) {
+            glm::vec2 lerped_mouse_ndc_coords =
+                glm::mix(this->last_mouse_ndc_coords, bundle.mouse_ndc_coords,
+                         (float)step / (float)flow_step_count);
+            bool skip_update_buffers = step < flow_step_count;
+
+            auto mouse_ray =
+                bundle.camera->screen_to_ray(lerped_mouse_ndc_coords);
+
+            // project mouse ray onto plane defined by plane_normal
+            float denom =
+                glm::dot(this->plane_normal.direction, mouse_ray.direction);
+            if (std::abs(denom) > 1e-6f) {
+                float t = glm::dot(this->plane_normal.origin - mouse_ray.origin,
+                                   this->plane_normal.direction) /
+                          denom;
+                if (t >= 0.0f) {
+                    // place voxel if hit
+                    glm::vec3 intersection =
+                        mouse_ray.origin + t * mouse_ray.direction;
+                    if (event.state & SDL_BUTTON_LEFT) {
+                        // add voxels
+                        bundle.scene->set_voxel_filled(
+                            this->depth, intersection, bundle.current_color,
+                            skip_update_buffers);
+                    } else {
+                        // remove voxels
+                        bundle.scene->set_voxel_empty(this->depth,
+                                                      intersection);
+                    }
                 }
             }
         }
     }
+
+    this->last_mouse_ndc_coords = bundle.mouse_ndc_coords;
 }
 
 auto VoxelBrush::handle_keyboard_event(const SDL_KeyboardEvent &event,

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -1,11 +1,10 @@
 #include "voxel-brush.h"
 
-#include "SDL3/SDL_events.h"
-#include "cursors.h"
+#include <SDL3/SDL_events.h>
+#include <imgui.h>
+#include <vxng/geometry.h>
 
-#include "imgui.h"
-
-VoxelBrush::VoxelBrush() : depth(9) {}
+VoxelBrush::VoxelBrush() : depth(9), plane_normal() {}
 
 VoxelBrush::~VoxelBrush() {}
 
@@ -49,6 +48,10 @@ auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
 
         bundle.scene->set_voxel_filled(this->depth, exterior_target_pos,
                                        bundle.current_color);
+        this->plane_normal = vxng::geometry::Ray{
+            .origin = exterior_target_pos,
+            .direction = raycast_result.normal,
+        };
         break;
     }
     case SDL_BUTTON_RIGHT: {
@@ -71,6 +74,28 @@ auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
         bundle.cursors->set_cursor(Cursors::Variant::POINTER);
     } else {
         bundle.cursors->set_cursor(Cursors::Variant::DEFAULT);
+    }
+
+    if (event.state & SDL_BUTTON_LEFT) {
+        auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
+
+        // project mouse ray onto plane defined by plane_normal
+        float denom =
+            glm::dot(this->plane_normal.direction, mouse_ray.direction);
+        if (std::abs(denom) > 1e-6f) {
+            float t = glm::dot(this->plane_normal.origin - mouse_ray.origin,
+                               this->plane_normal.direction) /
+                      denom;
+            if (t >= 0.0f) {
+                // place voxel if hit
+                glm::vec3 intersection =
+                    mouse_ray.origin + t * mouse_ray.direction;
+                glm::vec3 exterior_target_pos =
+                    intersection + this->plane_normal.direction * 0.00001f;
+                bundle.scene->set_voxel_filled(this->depth, exterior_target_pos,
+                                               bundle.current_color);
+            }
+        }
     }
 }
 

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -1,6 +1,5 @@
 #include "voxel-brush.h"
 
-#include <SDL3/SDL_events.h>
 #include <imgui.h>
 #include <vxng/geometry.h>
 
@@ -59,6 +58,10 @@ auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
         glm::vec3 interior_target_pos =
             target_pos - raycast_result.normal * 0.00001f;
         bundle.scene->set_voxel_empty(this->depth, interior_target_pos);
+        this->plane_normal = vxng::geometry::Ray{
+            .origin = target_pos,
+            .direction = raycast_result.normal,
+        };
         break;
     }
     }
@@ -76,7 +79,8 @@ auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
         bundle.cursors->set_cursor(Cursors::Variant::DEFAULT);
     }
 
-    if (event.state & SDL_BUTTON_LEFT) {
+    // do dragging logic
+    if (event.state & (SDL_BUTTON_LMASK | SDL_BUTTON_RMASK)) {
         auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
 
         // project mouse ray onto plane defined by plane_normal
@@ -90,10 +94,19 @@ auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
                 // place voxel if hit
                 glm::vec3 intersection =
                     mouse_ray.origin + t * mouse_ray.direction;
-                glm::vec3 exterior_target_pos =
-                    intersection + this->plane_normal.direction * 0.00001f;
-                bundle.scene->set_voxel_filled(this->depth, exterior_target_pos,
-                                               bundle.current_color);
+                if (event.state & SDL_BUTTON_LEFT) {
+                    // add voxels
+                    glm::vec3 exterior_target_pos =
+                        intersection + this->plane_normal.direction * 0.00001f;
+                    bundle.scene->set_voxel_filled(
+                        this->depth, exterior_target_pos, bundle.current_color);
+                } else {
+                    // remove voxels
+                    glm::vec3 interior_target_pos =
+                        intersection - this->plane_normal.direction * 0.00001f;
+                    bundle.scene->set_voxel_empty(this->depth,
+                                                  interior_target_pos);
+                }
             }
         }
     }

--- a/editor/src/tools/voxel-brush.h
+++ b/editor/src/tools/voxel-brush.h
@@ -19,9 +19,17 @@ class VoxelBrush : public EditorTool {
     auto handle_keyboard_event(const SDL_KeyboardEvent &event,
                                const EventBundle &bundle) -> void override;
 
+    typedef enum Mode {
+        AXIS_ALIGNED,
+        CAMERA_PLANE,
+    } Mode;
+
   private:
+    Mode current_mode;
     int depth;
+    float flow_density;
 
     // for tracking drags
     vxng::geometry::Ray plane_normal;
+    glm::vec2 last_mouse_ndc_coords;
 };

--- a/editor/src/tools/voxel-brush.h
+++ b/editor/src/tools/voxel-brush.h
@@ -2,6 +2,8 @@
 
 #include "tool.h"
 
+#include <vxng/geometry.h>
+
 class VoxelBrush : public EditorTool {
   public:
     VoxelBrush();
@@ -19,4 +21,7 @@ class VoxelBrush : public EditorTool {
 
   private:
     int depth;
+
+    // for tracking drags
+    vxng::geometry::Ray plane_normal;
 };

--- a/libs/vxng/include/vxng/camera.h
+++ b/libs/vxng/include/vxng/camera.h
@@ -21,10 +21,12 @@ class Camera {
 
     /** Creates world-space ray based on an NDC screen position */
     auto screen_to_ray(glm::vec2 screen_pos) const -> geometry::Ray;
+    auto get_forward() const -> glm::vec3;
 
     /** Updates the aspect ratio (width / height) for screen-to-ray conversion
      */
     auto set_aspect_ratio(float aspect_ratio) -> void;
+    auto get_aspect_ratio() const -> float;
 
   protected:
     Camera(glm::vec3 position, glm::mat3 rotation, float fovy_rad);

--- a/libs/vxng/include/vxng/geometry.h
+++ b/libs/vxng/include/vxng/geometry.h
@@ -12,6 +12,8 @@ typedef struct Ray {
 typedef struct AABB {
     glm::vec3 min;
     glm::vec3 max;
+
+    auto contains(glm::vec3 point) const -> bool;
 } AABB;
 
 typedef struct RayAABBIntersectResult {

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -27,8 +27,8 @@ class Scene {
 
     auto raycast(const geometry::Ray &ray) const -> geometry::RaycastResult;
 
-    auto set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color)
-        -> void;
+    auto set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color,
+                          bool skip_update_buffers = false) -> void;
     auto set_voxel_empty(int depth, glm::vec3 position) -> void;
 
     // --------- Utility ---------

--- a/libs/vxng/src/camera/camera.cpp
+++ b/libs/vxng/src/camera/camera.cpp
@@ -75,8 +75,12 @@ auto Camera::screen_to_ray(glm::vec2 screen_pos) const -> geometry::Ray {
     return ray;
 }
 
+auto Camera::get_forward() const -> glm::vec3 { return -this->rotation[2]; }
+
 auto Camera::set_aspect_ratio(float aspect_ratio) -> void {
     this->aspect_ratio = aspect_ratio;
 }
+
+auto Camera::get_aspect_ratio() const -> float { return this->aspect_ratio; }
 
 } // namespace vxng::camera

--- a/libs/vxng/src/geometry.cpp
+++ b/libs/vxng/src/geometry.cpp
@@ -48,23 +48,28 @@ auto ray_aabb_intersect(const Ray &ray, const AABB &aabb)
 
 auto compute_aabb_normal(const AABB &aabb, glm::vec3 intersection)
     -> glm::vec3 {
-    const float epsilon = 0.0001f;
+    float dx_min = std::abs(intersection.x - aabb.min.x);
+    float dx_max = std::abs(intersection.x - aabb.max.x);
+    float dy_min = std::abs(intersection.y - aabb.min.y);
+    float dy_max = std::abs(intersection.y - aabb.max.y);
+    float dz_min = std::abs(intersection.z - aabb.min.z);
+    float dz_max = std::abs(intersection.z - aabb.max.z);
 
-    if (std::abs(intersection.x - aabb.min.x) < epsilon) {
+    float min_dist = std::min({dx_min, dx_max, dy_min, dy_max, dz_min, dz_max});
+
+    if (min_dist == dx_min)
         return glm::vec3(-1.0f, 0.0f, 0.0f);
-    } else if (std::abs(intersection.x - aabb.max.x) < epsilon) {
+    if (min_dist == dx_max)
         return glm::vec3(1.0f, 0.0f, 0.0f);
-    } else if (std::abs(intersection.y - aabb.min.y) < epsilon) {
+    if (min_dist == dy_min)
         return glm::vec3(0.0f, -1.0f, 0.0f);
-    } else if (std::abs(intersection.y - aabb.max.y) < epsilon) {
+    if (min_dist == dy_max)
         return glm::vec3(0.0f, 1.0f, 0.0f);
-    } else if (std::abs(intersection.z - aabb.min.z) < epsilon) {
+    if (min_dist == dz_min)
         return glm::vec3(0.0f, 0.0f, -1.0f);
-    } else if (std::abs(intersection.z - aabb.max.z) < epsilon) {
+    if (min_dist == dz_max)
         return glm::vec3(0.0f, 0.0f, 1.0f);
-    }
 
-    // evil fallback just in case, shouldn't happen
     return glm::vec3(0.0f, 0.0f, 0.0f);
 }
 

--- a/libs/vxng/src/geometry.cpp
+++ b/libs/vxng/src/geometry.cpp
@@ -2,6 +2,12 @@
 
 namespace vxng::geometry {
 
+auto AABB::contains(glm::vec3 point) const -> bool {
+    return point.x >= this->min.x && point.x <= this->max.x &&
+           point.y >= this->min.y && point.y <= this->max.y &&
+           point.z >= this->min.z && point.z <= this->max.z;
+}
+
 // implementation based on libs/vxng/src/wgsl/chunk.wgsl.cpp
 auto ray_aabb_intersect(const Ray &ray, const AABB &aabb)
     -> RayAABBIntersectResult {

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -118,6 +118,7 @@ auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
         } else {
             // Internal node - push children onto stack in reverse order (for
             // DFS) We want to visit them in order 0-7, so push in reverse 7-0
+            bool ray_origin_inside = aabb.contains(ray.origin);
             for (int i = 7; i >= 0; --i) {
                 if (node->children[i]) {
                     // Compute child AABB
@@ -136,7 +137,8 @@ auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
                     // Check if ray could hit this child AABB before closest hit
                     auto child_result =
                         geometry::ray_aabb_intersect(ray, child_aabb);
-                    if (child_result.hit && child_result.t < closest_t) {
+                    if (child_result.hit &&
+                        (ray_origin_inside || child_result.t < closest_t)) {
                         stack.push_back({node->children[i].get(), child_aabb});
                     }
                 }

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -122,13 +122,13 @@ auto Scene::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
     return closest_hit;
 }
 
-auto Scene::set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color)
-    -> void {
+auto Scene::set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color,
+                             bool skip_update_buffers) -> void {
     auto chunked_location = get_chunked_location_info(position);
     Chunk *target_chunk = touch_chunk(chunked_location.chunk_coord);
 
     target_chunk->set_voxel_filled(depth, chunked_location.local_position,
-                                   color);
+                                   color, skip_update_buffers);
 }
 
 auto Scene::set_voxel_empty(int depth, glm::vec3 position) -> void {


### PR DESCRIPTION
This PR adds click and drag support for the brush, as well as some options!

It has two modes, "axis-aligned" and "camera plane". These define how voxels are placed when clicking and dragging.

<img width="912" height="744" alt="image" src="https://github.com/user-attachments/assets/0502ca5c-c508-46fe-85fa-1766c6b6fdea" />

## Changes

- Add click and drag support for brush
  - A plane is initialized upon clicking, oriented depending on the tool's "mode." `AXIS_ALIGNED` uses the grid axes, and `CAMERA_PLANE` uses the camera plane
- patch: improve normal checking algorithm (no longer using epsilon, just minimum now)
- patch: add `get_forward` method for `Camera`
- patch: add `skip_update_buffers` to scene voxel setting method for speed
- patch: add helper `AABB::contains` method
- fix: faulty CPU raycasts when done from inside an internal node