### PR TITLE
Add brush resizing

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -356,9 +356,10 @@ auto Editor::run_gui() -> void {
 
         ImGui::TextWrapped("More tools on the way!");
 
-        ImGui::Dummy(ImVec2(0.0f, 8.0f));
+        ImGui::Dummy(ImVec2(0.0f, 16.0f));
 
         // tool options section
+        ImGui::SeparatorText("Tool Options");
         auto tool_name = std::string(this->current_tool->get_tool_name());
         if (ImGui::CollapsingHeader((tool_name + "###ToolMenu").c_str(),
                                     ImGuiTreeNodeFlags_DefaultOpen)) {

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -4,8 +4,8 @@
 #include <vxng/geometry.h>
 
 VoxelBrush::VoxelBrush()
-    : current_mode(Mode::AXIS_ALIGNED), depth(9), flow_density(5.f),
-      plane_normal(), last_mouse_ndc_coords() {}
+    : current_mode(Mode::AXIS_ALIGNED), size(1), depth(9), flow_density(5.f),
+      plane_normal(), last_mouse_ndc_coords(), abs_brush_kernel() {}
 
 VoxelBrush::~VoxelBrush() {}
 
@@ -19,6 +19,9 @@ auto VoxelBrush::render_ui() -> void {
     if (ImGui::RadioButton("Camera plane",
                            this->current_mode == Mode::CAMERA_PLANE))
         this->current_mode = Mode::CAMERA_PLANE;
+
+    if (ImGui::SliderInt("Size", &this->size, 1, 5))
+        compute_brush_kernel();
 
     ImGui::SliderInt("Depth", &this->depth, 0, 9);
     ImGui::SliderFloat("Flow Density", &this->flow_density, 0.f, 20.f);
@@ -140,3 +143,17 @@ auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
 
 auto VoxelBrush::handle_keyboard_event(const SDL_KeyboardEvent &event,
                                        const EventBundle &bundle) -> void {}
+
+auto VoxelBrush::compute_brush_kernel() -> void {
+    this->abs_brush_kernel.clear();
+
+    for (int x = 0; x < this->size; ++x) {
+        for (int y = 0; y < this->size; ++y) {
+            for (int z = 0; z < this->size; ++z) {
+                float magnitude = glm::sqrt(x * x + y * y + z * z);
+                this->abs_brush_kernel[glm::uvec3(x, y, z)] =
+                    magnitude < this->size - 0.000001f;
+            }
+        }
+    }
+}

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -9,9 +9,7 @@ VoxelBrush::VoxelBrush()
 
 VoxelBrush::~VoxelBrush() {}
 
-auto VoxelBrush::get_tool_name() -> const char * {
-    return "Simple Voxel Brush";
-}
+auto VoxelBrush::get_tool_name() -> const char * { return "Voxel Brush"; }
 
 // no ui for this yet
 auto VoxelBrush::render_ui() -> void {

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -59,8 +59,7 @@ auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
         glm::vec3 exterior_target_pos =
             target_pos + raycast_result.normal * 0.00001f;
 
-        bundle.scene->set_voxel_filled(this->depth, exterior_target_pos,
-                                       bundle.current_color);
+        stamp_brush(StampMode::PLACE, exterior_target_pos, bundle);
         this->plane_normal = vxng::geometry::Ray{
             .origin = exterior_target_pos,
             .direction = plane_normal,
@@ -71,7 +70,8 @@ auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
         // go inside voxel boundary
         glm::vec3 interior_target_pos =
             target_pos - raycast_result.normal * 0.00001f;
-        bundle.scene->set_voxel_empty(this->depth, interior_target_pos);
+
+        stamp_brush(StampMode::DELETE, interior_target_pos, bundle);
         this->plane_normal = vxng::geometry::Ray{
             .origin = interior_target_pos,
             .direction = plane_normal,
@@ -104,10 +104,10 @@ auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
             glm::ceil(mouse_move_distance * this->flow_density);
 
         for (int step = 1; step <= flow_step_count; ++step) {
+            bool skip_update_buffers = step < flow_step_count;
             glm::vec2 lerped_mouse_ndc_coords =
                 glm::mix(this->last_mouse_ndc_coords, bundle.mouse_ndc_coords,
                          (float)step / (float)flow_step_count);
-            bool skip_update_buffers = step < flow_step_count;
 
             auto mouse_ray =
                 bundle.camera->screen_to_ray(lerped_mouse_ndc_coords);
@@ -123,16 +123,11 @@ auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
                     // place voxel if hit
                     glm::vec3 intersection =
                         mouse_ray.origin + t * mouse_ray.direction;
-                    if (event.state & SDL_BUTTON_LEFT) {
-                        // add voxels
-                        bundle.scene->set_voxel_filled(
-                            this->depth, intersection, bundle.current_color,
-                            skip_update_buffers);
-                    } else {
-                        // remove voxels
-                        bundle.scene->set_voxel_empty(this->depth,
-                                                      intersection);
-                    }
+
+                    bool placing = event.state & SDL_BUTTON_LEFT;
+                    // add/remove voxels
+                    stamp_brush(placing ? StampMode::PLACE : StampMode::DELETE,
+                                intersection, bundle, skip_update_buffers);
                 }
             }
         }
@@ -152,8 +147,58 @@ auto VoxelBrush::compute_brush_kernel() -> void {
             for (int z = 0; z < this->size; ++z) {
                 float magnitude = glm::sqrt(x * x + y * y + z * z);
                 this->abs_brush_kernel[glm::uvec3(x, y, z)] =
-                    magnitude < this->size - 0.000001f;
+                    magnitude < (this->size - 0.5f);
             }
         }
+    }
+}
+
+auto VoxelBrush::stamp_brush(StampMode mode, glm::vec3 position,
+                             const EventBundle &bundle,
+                             bool skip_update_buffers) -> void {
+    float voxel_size =
+        bundle.scene->get_chunk_scale() / (float)(1u << this->depth);
+
+    for (int x = 0; x < this->size; ++x) {
+        for (int y = 0; y < this->size; ++y) {
+            for (int z = 0; z < this->size; ++z) {
+                auto kernel_result =
+                    this->abs_brush_kernel.find(glm::uvec3(x, y, z));
+
+                // skip if not found, or if marked as
+                if (kernel_result == this->abs_brush_kernel.end())
+                    continue;
+                if (!kernel_result->second)
+                    continue;
+
+                for (int i = 0; i < 8; ++i) {
+                    glm::vec3 signs = glm::vec3(1u & (i >> 0u), 1u & (i >> 1u),
+                                                1u & (i >> 2u)) *
+                                          2.f -
+                                      1.f;
+
+                    if (mode == StampMode::PLACE) {
+                        bundle.scene->set_voxel_filled(
+                            this->depth,
+                            position + glm::vec3(x, y, z) * signs * voxel_size,
+                            bundle.current_color, true);
+                    } else {
+                        bundle.scene->set_voxel_empty(
+                            this->depth,
+                            position + glm::vec3(x, y, z) * signs * voxel_size,
+                            true);
+                    }
+                }
+            }
+        }
+    }
+
+    // set base node
+    if (mode == StampMode::PLACE) {
+        bundle.scene->set_voxel_filled(
+            this->depth, position, bundle.current_color, skip_update_buffers);
+    } else {
+        bundle.scene->set_voxel_empty(this->depth, position,
+                                      skip_update_buffers);
     }
 }

--- a/editor/src/tools/voxel-brush.h
+++ b/editor/src/tools/voxel-brush.h
@@ -4,6 +4,8 @@
 
 #include <vxng/geometry.h>
 
+#include <unordered_map>
+
 class VoxelBrush : public EditorTool {
   public:
     VoxelBrush();
@@ -26,10 +28,15 @@ class VoxelBrush : public EditorTool {
 
   private:
     Mode current_mode;
+    int size;
     int depth;
     float flow_density;
 
     // for tracking drags
     vxng::geometry::Ray plane_normal;
     glm::vec2 last_mouse_ndc_coords;
+
+    // for brush sizing
+    auto compute_brush_kernel() -> void;
+    std::unordered_map<glm::uvec3, bool> abs_brush_kernel;
 };

--- a/editor/src/tools/voxel-brush.h
+++ b/editor/src/tools/voxel-brush.h
@@ -3,6 +3,7 @@
 #include "tool.h"
 
 #include <vxng/geometry.h>
+#include <vxng/scene.h>
 
 #include <unordered_map>
 
@@ -37,6 +38,13 @@ class VoxelBrush : public EditorTool {
     glm::vec2 last_mouse_ndc_coords;
 
     // for brush sizing
-    auto compute_brush_kernel() -> void;
     std::unordered_map<glm::uvec3, bool> abs_brush_kernel;
+
+    auto compute_brush_kernel() -> void;
+
+    typedef enum StampMode { PLACE, DELETE } StampMode;
+
+    auto stamp_brush(StampMode mode, glm::vec3 position,
+                     const EventBundle &bundle,
+                     bool skip_update_buffers = false) -> void;
 };

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -29,7 +29,8 @@ class Scene {
 
     auto set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color,
                           bool skip_update_buffers = false) -> void;
-    auto set_voxel_empty(int depth, glm::vec3 position) -> void;
+    auto set_voxel_empty(int depth, glm::vec3 position,
+                         bool skip_update_buffers = false) -> void;
 
     // --------- Utility ---------
 

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -167,7 +167,8 @@ auto Chunk::set_voxel_filled(int depth, glm::vec3 local_position,
         update_buffers();
 };
 
-auto Chunk::set_voxel_empty(int depth, glm::vec3 local_position) -> void {
+auto Chunk::set_voxel_empty(int depth, glm::vec3 local_position,
+                            bool skip_update_buffers) -> void {
     // dig first for the node we want to edit
     OctreeNode *node = dig_into_tree(local_position, depth);
 

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -61,7 +61,8 @@ class Chunk {
     auto set_voxel_filled(int depth, glm::vec3 local_position,
                           glm::u8vec4 color, bool skip_update_buffers = false)
         -> void;
-    auto set_voxel_empty(int depth, glm::vec3 local_position) -> void;
+    auto set_voxel_empty(int depth, glm::vec3 local_position,
+                         bool skip_update_buffers = false) -> void;
     auto set_voxel_grid_data(const uint8_t *data, glm::ivec3 size,
                              const std::array<glm::u8vec4, 256> &palette,
                              glm::ivec3 offset) -> void;

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -131,11 +131,13 @@ auto Scene::set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color,
                                    color, skip_update_buffers);
 }
 
-auto Scene::set_voxel_empty(int depth, glm::vec3 position) -> void {
+auto Scene::set_voxel_empty(int depth, glm::vec3 position,
+                            bool skip_update_buffers) -> void {
     auto chunked_location = get_chunked_location_info(position);
     Chunk *target_chunk = touch_chunk(chunked_location.chunk_coord);
 
-    target_chunk->set_voxel_empty(depth, chunked_location.local_position);
+    target_chunk->set_voxel_empty(depth, chunked_location.local_position,
+                                  skip_update_buffers);
 }
 
 auto Scene::get_chunk_scale() const -> float { return this->chunk_scale; }


### PR DESCRIPTION
This PR adds a "size" slider for the voxel brush! This works across any depth.

We precompute a simple kernel for a given brush size, then sample it when stamping the brush in the world.

<img width="912" height="744" alt="image" src="https://github.com/user-attachments/assets/f510649c-eabb-42dd-abd5-ebb28414d778" />

## Changes

- Add brush sizing parameter, tweakable in UI
  - Precomputes kernel in `compute_brush_kernel`, then samples in `stamp_brush`
- patch: make tool options ui spacing cleaner
- patch: add optional `skip_update_buffers` param to `Chunk::set_voxel_empty` and `Scene::set_voxel_empty`