### PR TITLE
Add paintbrush tool

### DIFF
--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(${PROJECT_NAME})
 
 target_sources(${PROJECT_NAME}
     PRIVATE
+        src/tools/shared/brush-kernel.cpp
         src/tools/voxel-brush.cpp
         src/cursors.cpp
         src/editor.cpp

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(${PROJECT_NAME}
     PRIVATE
         src/tools/shared/brush-kernel.cpp
         src/tools/draggable-tool.cpp
+        src/tools/paint-brush.cpp
         src/tools/voxel-brush.cpp
         src/cursors.cpp
         src/editor.cpp

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(${PROJECT_NAME})
 target_sources(${PROJECT_NAME}
     PRIVATE
         src/tools/shared/brush-kernel.cpp
+        src/tools/draggable-tool.cpp
         src/tools/voxel-brush.cpp
         src/cursors.cpp
         src/editor.cpp

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -598,10 +598,18 @@ auto Editor::handle_mouse_motion(const SDL_MouseMotionEvent &event) -> void {
 }
 
 auto Editor::handle_mouse_down(const SDL_MouseButtonEvent &event) -> void {
+    SDL_Keymod mods = SDL_GetModState();
+    if (mods & SDL_KMOD_ALT)
+        return; // using navigation mode
+
     this->current_tool->handle_mouse_button_event(event, make_event_bundle());
 }
 
 auto Editor::handle_mouse_up(const SDL_MouseButtonEvent &event) -> void {
+    SDL_Keymod mods = SDL_GetModState();
+    if (mods & SDL_KMOD_ALT)
+        return; // using navigation mode
+
     this->current_tool->handle_mouse_button_event(event, make_event_bundle());
 }
 

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -352,7 +352,7 @@ auto Editor::run_gui() -> void {
         ImGui::SeparatorText("Tool Selection");
         if (ImGui::RadioButton("Voxel Brush",
                                this->current_tool == &this->tools.voxel_brush))
-            this->current_tool = &this->tools.voxel_brush;
+            set_active_tool(&this->tools.voxel_brush);
 
         ImGui::TextWrapped("More tools on the way!");
 
@@ -572,6 +572,10 @@ auto Editor::handle_mouse_motion(const SDL_MouseMotionEvent &event) -> void {
 
     // camera movement (only if alt is held)
     if (mods & SDL_KMOD_ALT) {
+        if (this->is_tool_active) {
+            this->current_tool->handle_deactivate(make_event_bundle());
+            this->is_tool_active = false;
+        }
         if (event.state & SDL_BUTTON_LMASK) {
             this->viewport_camera.handle_rotation(event.xrel, event.yrel);
             this->cursors.set_cursor(Cursors::Variant::MOVE);
@@ -584,8 +588,12 @@ auto Editor::handle_mouse_motion(const SDL_MouseMotionEvent &event) -> void {
         }
     } else {
         // no mod held, pass off to current tool
-        this->current_tool->handle_mouse_motion_event(event,
-                                                      make_event_bundle());
+        auto event_bundle = make_event_bundle();
+        if (!this->is_tool_active) {
+            this->current_tool->handle_activate(make_event_bundle());
+            this->is_tool_active = true;
+        }
+        this->current_tool->handle_mouse_motion_event(event, event_bundle);
     }
 }
 
@@ -604,6 +612,15 @@ auto Editor::new_empty_scene() -> void {
     this->scene->init_webgpu(this->wgpu.device);
 
     this->renderer.set_scene(this->scene.get());
+}
+
+auto Editor::set_active_tool(EditorTool *tool) -> void {
+    auto event_bundle = make_event_bundle();
+
+    if (this->is_tool_active)
+        current_tool->handle_deactivate(event_bundle);
+    this->current_tool = tool;
+    tool->handle_activate(event_bundle);
 }
 
 auto Editor::make_event_bundle() -> EditorTool::EventBundle {

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -353,6 +353,9 @@ auto Editor::run_gui() -> void {
         if (ImGui::RadioButton("Voxel Brush",
                                this->current_tool == &this->tools.voxel_brush))
             set_active_tool(&this->tools.voxel_brush);
+        if (ImGui::RadioButton("Paintbrush",
+                               this->current_tool == &this->tools.paint_brush))
+            set_active_tool(&this->tools.paint_brush);
 
         ImGui::TextWrapped("More tools on the way!");
 

--- a/editor/src/editor.h
+++ b/editor/src/editor.h
@@ -59,6 +59,7 @@ class Editor {
         VoxelBrush voxel_brush;
     } tools;
     EditorTool *current_tool;
+    bool is_tool_active;
     Palette palette;
 
     struct {
@@ -68,6 +69,8 @@ class Editor {
 
     // menu options
     auto new_empty_scene() -> void;
+
+    auto set_active_tool(EditorTool *tool) -> void;
 
     auto make_event_bundle() -> EditorTool::EventBundle;
 };

--- a/editor/src/editor.h
+++ b/editor/src/editor.h
@@ -3,6 +3,7 @@
 #include "cursors.h"
 #include "palette.h"
 #include "tool.h"
+#include "tools/paint-brush.h"
 #include "tools/tools.h"
 
 #include <SDL3/SDL.h>
@@ -57,6 +58,7 @@ class Editor {
 
     struct {
         VoxelBrush voxel_brush;
+        PaintBrush paint_brush;
     } tools;
     EditorTool *current_tool;
     bool is_tool_active;

--- a/editor/src/tool.h
+++ b/editor/src/tool.h
@@ -33,4 +33,7 @@ class EditorTool {
         -> void = 0;
     virtual auto handle_keyboard_event(const SDL_KeyboardEvent &event,
                                        const EventBundle &bundle) -> void = 0;
+
+    virtual auto handle_activate(const EventBundle &bundle) -> void = 0;
+    virtual auto handle_deactivate(const EventBundle &bundle) -> void = 0;
 };

--- a/editor/src/tools/draggable-tool.cpp
+++ b/editor/src/tools/draggable-tool.cpp
@@ -23,7 +23,7 @@ auto DraggableTool::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
     -> void {
     if (event.down) {
         // start tracking this drag
-        this->drag_buttonmask = this->drag_buttonmask | (1u << event.button);
+        this->drag_buttonmask |= SDL_BUTTON_MASK(event.button);
     }
 }
 
@@ -53,12 +53,14 @@ auto DraggableTool::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
         int flow_step_count =
             glm::ceil(mouse_move_distance * this->flow_density);
 
-        for (int step = 1; step <= flow_step_count; ++step) {
+        for (int step = 0; step < flow_step_count; ++step) {
             glm::vec2 lerped_mouse_ndc_coords =
                 glm::mix(this->last_mouse_ndc_coords, bundle.mouse_ndc_coords,
-                         (float)step / (float)flow_step_count);
+                         (float)(step + 1.f) / (float)flow_step_count);
 
-            handle_drag_step(step, flow_step_count, lerped_mouse_ndc_coords);
+            // pass to implementer
+            handle_drag_step(step, flow_step_count, lerped_mouse_ndc_coords,
+                             bundle);
         }
     }
 

--- a/editor/src/tools/draggable-tool.cpp
+++ b/editor/src/tools/draggable-tool.cpp
@@ -3,8 +3,9 @@
 #include <imgui.h>
 #include <vxng/geometry.h>
 
-DraggableTool::DraggableTool()
-    : flow_density(5.f), drag_buttonmask(0u), last_mouse_ndc_coords() {}
+DraggableTool::DraggableTool(float flow_density)
+    : flow_density(flow_density), drag_buttonmask(0u), last_mouse_ndc_coords() {
+}
 
 DraggableTool::~DraggableTool() {}
 

--- a/editor/src/tools/draggable-tool.cpp
+++ b/editor/src/tools/draggable-tool.cpp
@@ -1,0 +1,72 @@
+#include "draggable-tool.h"
+
+#include <imgui.h>
+#include <vxng/geometry.h>
+
+DraggableTool::DraggableTool()
+    : flow_density(5.f), drag_buttonmask(0u), last_mouse_ndc_coords() {}
+
+DraggableTool::~DraggableTool() {}
+
+auto DraggableTool::render_flow_density_ui() -> void {
+    ImGui::SliderFloat("Flow Density", &this->flow_density, 0.f, 20.f);
+}
+
+auto DraggableTool::is_mousebutton_dragging(int sdl_mousebutton) -> bool {
+    return (bool)(this->drag_buttonmask & SDL_BUTTON_MASK(sdl_mousebutton));
+}
+
+auto DraggableTool::cancel_dragging() -> void { this->drag_buttonmask = 0u; }
+
+auto DraggableTool::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
+                                              const EventBundle &bundle)
+    -> void {
+    if (event.down) {
+        // start tracking this drag
+        this->drag_buttonmask = this->drag_buttonmask | (1u << event.button);
+    }
+}
+
+auto DraggableTool::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
+                                              const EventBundle &bundle)
+    -> void {
+    auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
+    auto raycast_result = bundle.scene->raycast(mouse_ray);
+
+    // clear drag state if button not held (all buttons)
+    bool is_any_button_held = false;
+    for (int button = 1; button <= 5; ++button) {
+        int buttonmask = SDL_BUTTON_MASK(button);
+        if (!(event.state & buttonmask)) {
+            this->drag_buttonmask &= ~buttonmask;
+            is_any_button_held = true;
+        }
+    }
+
+    // check dragging buttonmask
+    if (is_any_button_held) {
+        float mouse_move_distance =
+            ((bundle.mouse_ndc_coords - this->last_mouse_ndc_coords) *
+             glm::vec2(bundle.camera->get_aspect_ratio(), 1.f))
+                .length();
+
+        int flow_step_count =
+            glm::ceil(mouse_move_distance * this->flow_density);
+
+        for (int step = 1; step <= flow_step_count; ++step) {
+            glm::vec2 lerped_mouse_ndc_coords =
+                glm::mix(this->last_mouse_ndc_coords, bundle.mouse_ndc_coords,
+                         (float)step / (float)flow_step_count);
+
+            handle_drag_step(step, flow_step_count, lerped_mouse_ndc_coords);
+        }
+    }
+
+    this->last_mouse_ndc_coords = bundle.mouse_ndc_coords;
+}
+
+auto DraggableTool::handle_activate(const EventBundle &bundle) -> void {}
+
+auto DraggableTool::handle_deactivate(const EventBundle &bundle) -> void {
+    this->drag_buttonmask = 0u;
+}

--- a/editor/src/tools/draggable-tool.h
+++ b/editor/src/tools/draggable-tool.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "tool.h"
+
+#include <vxng/geometry.h>
+#include <vxng/scene.h>
+
+class DraggableTool : public EditorTool {
+  public:
+    DraggableTool();
+    ~DraggableTool();
+
+    virtual auto handle_mouse_button_event(const SDL_MouseButtonEvent &event,
+                                           const EventBundle &bundle)
+        -> void override;
+    virtual auto handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
+                                           const EventBundle &bundle)
+        -> void override;
+
+    virtual auto handle_activate(const EventBundle &bundle) -> void override;
+    virtual auto handle_deactivate(const EventBundle &bundle) -> void override;
+
+  protected:
+    float flow_density;
+
+    // consumable by implementations
+    auto render_flow_density_ui() -> void;
+    auto is_mousebutton_dragging(int sdl_mousebutton) -> bool;
+    auto cancel_dragging() -> void;
+
+  private:
+    // for tracking drags
+    uint32_t drag_buttonmask;
+    glm::vec2 last_mouse_ndc_coords;
+
+    // to be overridden by implementations
+    virtual auto handle_drag_step(int step_idx, int total_steps,
+                                  glm::vec2 step_ndc_mouse_coords) -> void = 0;
+};

--- a/editor/src/tools/draggable-tool.h
+++ b/editor/src/tools/draggable-tool.h
@@ -7,7 +7,7 @@
 
 class DraggableTool : public EditorTool {
   public:
-    DraggableTool();
+    DraggableTool(float flow_density);
     ~DraggableTool();
 
     virtual auto handle_mouse_button_event(const SDL_MouseButtonEvent &event,

--- a/editor/src/tools/draggable-tool.h
+++ b/editor/src/tools/draggable-tool.h
@@ -35,5 +35,6 @@ class DraggableTool : public EditorTool {
 
     // to be overridden by implementations
     virtual auto handle_drag_step(int step_idx, int total_steps,
-                                  glm::vec2 step_ndc_mouse_coords) -> void = 0;
+                                  glm::vec2 step_ndc_mouse_coords,
+                                  const EventBundle &bundle) -> void = 0;
 };

--- a/editor/src/tools/paint-brush.cpp
+++ b/editor/src/tools/paint-brush.cpp
@@ -1,0 +1,108 @@
+#include "paint-brush.h"
+
+#include <imgui.h>
+#include <vxng/geometry.h>
+
+#include <cmath>
+
+PaintBrush::PaintBrush() : DraggableTool(5.f), size(2), brush_kernel(size) {}
+
+PaintBrush::~PaintBrush() {}
+
+auto PaintBrush::get_tool_name() -> const char * { return "Paintbrush"; }
+
+// no ui for this yet
+auto PaintBrush::render_ui() -> void {
+    if (ImGui::SliderInt("Size", &this->size, 1, 10))
+        this->brush_kernel.set_size(this->size);
+
+    this->render_flow_density_ui();
+}
+
+auto PaintBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
+                                           const EventBundle &bundle) -> void {
+    DraggableTool::handle_mouse_button_event(event, bundle);
+
+    // we don't care about mouse up
+    if (!event.down)
+        return;
+
+    // only care about left click
+    if (event.button != SDL_BUTTON_LEFT)
+        return;
+
+    auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
+    auto raycast_result = bundle.scene->raycast(mouse_ray);
+
+    // if nothing hit or we're inside something, do nothing
+    if (!raycast_result.hit || raycast_result.inside) {
+        return;
+    }
+
+    glm::vec3 target_pos =
+        mouse_ray.origin + raycast_result.t * mouse_ray.direction;
+    glm::vec3 interior_target_pos =
+        target_pos - raycast_result.normal * 0.00001f;
+
+    // apply paint!
+    stamp_paint(interior_target_pos, bundle);
+}
+
+auto PaintBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
+                                           const EventBundle &bundle) -> void {
+    DraggableTool::handle_mouse_motion_event(event, bundle);
+
+    auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
+    auto raycast_result = bundle.scene->raycast(mouse_ray);
+
+    // set pointer to "cursor" if raycast hit something
+    if (raycast_result.hit) {
+        bundle.cursors->set_cursor(Cursors::Variant::POINTER);
+    } else {
+        bundle.cursors->set_cursor(Cursors::Variant::DEFAULT);
+    }
+}
+
+auto PaintBrush::handle_keyboard_event(const SDL_KeyboardEvent &event,
+                                       const EventBundle &bundle) -> void {}
+
+auto PaintBrush::handle_drag_step(int step_idx, int total_steps,
+                                  glm::vec2 step_mouse_ndc_coords,
+                                  const EventBundle &bundle) -> void {
+
+    bool is_lmb_dragging = this->is_mousebutton_dragging(SDL_BUTTON_LEFT);
+
+    if (is_lmb_dragging) {
+        // only update buffers on last drag step
+        bool skip_update_buffers = step_idx < total_steps - 1;
+
+        auto mouse_ray = bundle.camera->screen_to_ray(step_mouse_ndc_coords);
+        auto raycast_result = bundle.scene->raycast(mouse_ray);
+        glm::vec3 target_pos =
+            mouse_ray.origin + raycast_result.t * mouse_ray.direction;
+        glm::vec3 interior_target_pos =
+            target_pos - raycast_result.normal * 0.00001f;
+
+        stamp_paint(interior_target_pos, bundle, skip_update_buffers);
+    }
+}
+
+auto PaintBrush::stamp_paint(glm::vec3 position, const EventBundle &bundle,
+                             bool skip_update_buffers) -> void {
+    int max_depth = std::log2(bundle.scene->get_chunk_resolution());
+    float voxel_size =
+        bundle.scene->get_chunk_scale() / bundle.scene->get_chunk_resolution();
+
+    for (auto &ioffset : this->brush_kernel.get_kernel()) {
+        glm::vec3 offset_position = position + glm::vec3(ioffset) * voxel_size;
+
+        auto sample = bundle.scene->sample_position(offset_position);
+        if (sample.has_value() && sample.value() != bundle.current_color)
+            bundle.scene->set_voxel_filled(max_depth, offset_position,
+                                           bundle.current_color, true);
+    }
+
+    // set last guy
+    bundle.scene->set_voxel_filled(max_depth, position, bundle.current_color,
+                                   skip_update_buffers);
+}

--- a/editor/src/tools/paint-brush.h
+++ b/editor/src/tools/paint-brush.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "tools/draggable-tool.h"
+#include "tools/shared/brush-kernel.h"
+
+#include <vxng/geometry.h>
+#include <vxng/scene.h>
+
+class PaintBrush : public DraggableTool {
+  public:
+    PaintBrush();
+    ~PaintBrush();
+
+    auto get_tool_name() -> const char * override;
+    auto render_ui() -> void override;
+
+    auto handle_mouse_button_event(const SDL_MouseButtonEvent &event,
+                                   const EventBundle &bundle) -> void override;
+    auto handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
+                                   const EventBundle &bundle) -> void override;
+    auto handle_keyboard_event(const SDL_KeyboardEvent &event,
+                               const EventBundle &bundle) -> void override;
+
+  private:
+    // params
+    int size;
+
+    // stamping
+    BrushKernel brush_kernel;
+
+    auto handle_drag_step(int step_idx, int total_steps,
+                          glm::vec2 step_mouse_ndc_coords,
+                          const EventBundle &bundle) -> void override;
+
+    auto stamp_paint(glm::vec3 position, const EventBundle &bundle,
+                     bool skip_update_buffers = false) -> void;
+};

--- a/editor/src/tools/shared/brush-kernel.cpp
+++ b/editor/src/tools/shared/brush-kernel.cpp
@@ -1,0 +1,38 @@
+#include "brush-kernel.h"
+
+BrushKernel::BrushKernel(int size) : size(size), kernel() {
+    regenerate_kernel();
+}
+BrushKernel::~BrushKernel() {}
+
+auto BrushKernel::set_size(int size) -> void {
+    this->size = size;
+    regenerate_kernel();
+}
+
+auto BrushKernel::get_size() const -> int { return this->size; }
+
+auto BrushKernel::sample(glm::ivec3 pos) const -> bool {
+    auto kernel_result = this->kernel.find(pos);
+    // true if we found coord in the kernel
+    return kernel_result != this->kernel.end();
+}
+
+auto BrushKernel::get_kernel() const -> const std::unordered_set<glm::ivec3> & {
+    return this->kernel;
+}
+
+auto BrushKernel::regenerate_kernel() -> void {
+    this->kernel.clear();
+
+    int iter_start = -this->size + 1;
+    for (int x = iter_start; x < this->size; ++x) {
+        for (int y = iter_start; y < this->size; ++y) {
+            for (int z = iter_start; z < this->size; ++z) {
+                float magnitude = glm::sqrt(x * x + y * y + z * z);
+                if (magnitude < (this->size - 0.5f))
+                    this->kernel.insert(glm::ivec3(x, y, z));
+            }
+        }
+    }
+}

--- a/editor/src/tools/shared/brush-kernel.h
+++ b/editor/src/tools/shared/brush-kernel.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/hash.hpp>
+
+#include <unordered_set>
+
+class BrushKernel {
+  public:
+    BrushKernel(int size);
+    ~BrushKernel();
+
+    auto set_size(int size) -> void;
+    auto get_size() const -> int;
+    auto sample(glm::ivec3 pos) const -> bool;
+    auto get_kernel() const -> const std::unordered_set<glm::ivec3> &;
+
+  private:
+    int size;
+    std::unordered_set<glm::ivec3> kernel;
+
+    auto regenerate_kernel() -> void;
+};

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -5,7 +5,8 @@
 
 VoxelBrush::VoxelBrush()
     : current_mode(Mode::AXIS_ALIGNED), size(1), depth(9), flow_density(5.f),
-      plane_normal(), last_mouse_ndc_coords(), brush_kernel(size) {}
+      drag_buttonmask(0u), plane_normal(), last_mouse_ndc_coords(),
+      brush_kernel(size) {}
 
 VoxelBrush::~VoxelBrush() {}
 
@@ -37,6 +38,9 @@ auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
     SDL_Keymod mods = SDL_GetModState();
     if (mods != SDL_KMOD_NONE)
         return;
+
+    // confirmed we clicked! track this drag
+    this->drag_buttonmask = this->drag_buttonmask | (1u << event.button);
 
     auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
     auto raycast_result = bundle.scene->raycast(mouse_ray);
@@ -93,8 +97,22 @@ auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
         bundle.cursors->set_cursor(Cursors::Variant::DEFAULT);
     }
 
-    // do dragging logic
-    if (event.state & (SDL_BUTTON_LMASK | SDL_BUTTON_RMASK)) {
+    bool is_lmb_held = event.state & SDL_BUTTON_LMASK;
+    bool is_rmb_held = event.state & SDL_BUTTON_RMASK;
+
+    // clear drag state if button not held
+    if (!is_lmb_held)
+        this->drag_buttonmask =
+            ~(~this->drag_buttonmask | (1u << SDL_BUTTON_LEFT));
+    if (!is_rmb_held)
+        this->drag_buttonmask =
+            ~(~this->drag_buttonmask | (1u << SDL_BUTTON_RIGHT));
+
+    bool is_lmb_dragging = this->drag_buttonmask & (1u << SDL_BUTTON_LEFT);
+    bool is_rmb_dragging = this->drag_buttonmask & (1u << SDL_BUTTON_RIGHT);
+
+    // check dragging buttonmask
+    if (is_lmb_dragging || is_rmb_dragging) {
         float mouse_move_distance =
             ((bundle.mouse_ndc_coords - this->last_mouse_ndc_coords) *
              glm::vec2(bundle.camera->get_aspect_ratio(), 1.f))
@@ -124,7 +142,7 @@ auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
                     glm::vec3 intersection =
                         mouse_ray.origin + t * mouse_ray.direction;
 
-                    StampMode stamp_mode = (event.state & SDL_BUTTON_LEFT)
+                    StampMode stamp_mode = (is_lmb_dragging)
                                                ? StampMode::PLACE
                                                : StampMode::DELETE;
                     // add/remove voxels

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -1,12 +1,12 @@
 #include "voxel-brush.h"
+#include "tools/draggable-tool.h"
 
 #include <imgui.h>
 #include <vxng/geometry.h>
 
 VoxelBrush::VoxelBrush()
     : current_mode(Mode::AXIS_ALIGNED), size(1), depth(9), flow_density(5.f),
-      drag_buttonmask(0u), plane_normal(), last_mouse_ndc_coords(),
-      brush_kernel(size) {}
+      plane_normal(), brush_kernel(size) {}
 
 VoxelBrush::~VoxelBrush() {}
 
@@ -25,26 +25,20 @@ auto VoxelBrush::render_ui() -> void {
         this->brush_kernel.set_size(this->size);
 
     ImGui::SliderInt("Depth", &this->depth, 0, 9);
-    ImGui::SliderFloat("Flow Density", &this->flow_density, 0.f, 20.f);
+    this->render_flow_density_ui();
 }
 
 auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
                                            const EventBundle &bundle) -> void {
+    DraggableTool::handle_mouse_button_event(event, bundle);
+
     // we don't care about mouse up
     if (!event.down)
-        return;
-
-    // don't do anything if any mods are held
-    SDL_Keymod mods = SDL_GetModState();
-    if (mods != SDL_KMOD_NONE)
         return;
 
     // only care about left and right click
     if (event.button != SDL_BUTTON_LEFT && event.button != SDL_BUTTON_RIGHT)
         return;
-
-    // confirmed we clicked! track this drag
-    this->drag_buttonmask = this->drag_buttonmask | (1u << event.button);
 
     auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
     auto raycast_result = bundle.scene->raycast(mouse_ray);
@@ -91,6 +85,8 @@ auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
 
 auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
                                            const EventBundle &bundle) -> void {
+    DraggableTool::handle_mouse_motion_event(event, bundle);
+
     auto mouse_ray = bundle.camera->screen_to_ray(bundle.mouse_ndc_coords);
     auto raycast_result = bundle.scene->raycast(mouse_ray);
 
@@ -100,68 +96,44 @@ auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
     } else {
         bundle.cursors->set_cursor(Cursors::Variant::DEFAULT);
     }
-
-    bool is_lmb_held = event.state & SDL_BUTTON_LMASK;
-    bool is_rmb_held = event.state & SDL_BUTTON_RMASK;
-
-    // clear drag state if button not held
-    if (!is_lmb_held)
-        this->drag_buttonmask =
-            ~(~this->drag_buttonmask | (1u << SDL_BUTTON_LEFT));
-    if (!is_rmb_held)
-        this->drag_buttonmask =
-            ~(~this->drag_buttonmask | (1u << SDL_BUTTON_RIGHT));
-
-    bool is_lmb_dragging = this->drag_buttonmask & (1u << SDL_BUTTON_LEFT);
-    bool is_rmb_dragging = this->drag_buttonmask & (1u << SDL_BUTTON_RIGHT);
-
-    // check dragging buttonmask
-    if (is_lmb_dragging || is_rmb_dragging) {
-        float mouse_move_distance =
-            ((bundle.mouse_ndc_coords - this->last_mouse_ndc_coords) *
-             glm::vec2(bundle.camera->get_aspect_ratio(), 1.f))
-                .length();
-
-        int flow_step_count =
-            glm::ceil(mouse_move_distance * this->flow_density);
-
-        for (int step = 1; step <= flow_step_count; ++step) {
-            bool skip_update_buffers = step < flow_step_count;
-            glm::vec2 lerped_mouse_ndc_coords =
-                glm::mix(this->last_mouse_ndc_coords, bundle.mouse_ndc_coords,
-                         (float)step / (float)flow_step_count);
-
-            auto mouse_ray =
-                bundle.camera->screen_to_ray(lerped_mouse_ndc_coords);
-
-            // project mouse ray onto plane defined by plane_normal
-            float denom =
-                glm::dot(this->plane_normal.direction, mouse_ray.direction);
-            if (std::abs(denom) > 1e-6f) {
-                float t = glm::dot(this->plane_normal.origin - mouse_ray.origin,
-                                   this->plane_normal.direction) /
-                          denom;
-                if (t >= 0.0f) {
-                    // place voxel if hit
-                    glm::vec3 intersection =
-                        mouse_ray.origin + t * mouse_ray.direction;
-
-                    StampMode stamp_mode = (is_lmb_dragging)
-                                               ? StampMode::PLACE
-                                               : StampMode::DELETE;
-                    // add/remove voxels
-                    stamp_brush(stamp_mode, intersection, bundle,
-                                skip_update_buffers);
-                }
-            }
-        }
-    }
-
-    this->last_mouse_ndc_coords = bundle.mouse_ndc_coords;
 }
 
 auto VoxelBrush::handle_keyboard_event(const SDL_KeyboardEvent &event,
                                        const EventBundle &bundle) -> void {}
+
+auto VoxelBrush::handle_drag_step(int step_idx, int total_steps,
+                                  glm::vec2 step_mouse_ndc_coords,
+                                  const EventBundle &bundle) -> void {
+
+    bool is_lmb_dragging = this->is_mousebutton_dragging(SDL_BUTTON_LEFT);
+    bool is_rmb_dragging = this->is_mousebutton_dragging(SDL_BUTTON_RIGHT);
+
+    if (is_lmb_dragging || is_rmb_dragging) {
+        bool skip_update_buffers = step_idx < total_steps - 1;
+
+        auto mouse_ray = bundle.camera->screen_to_ray(step_mouse_ndc_coords);
+
+        // project mouse ray onto plane defined by plane_normal
+        float denom =
+            glm::dot(this->plane_normal.direction, mouse_ray.direction);
+        if (std::abs(denom) > 1e-6f) {
+            float t = glm::dot(this->plane_normal.origin - mouse_ray.origin,
+                               this->plane_normal.direction) /
+                      denom;
+            if (t >= 0.0f) {
+                // place voxel if hit
+                glm::vec3 intersection =
+                    mouse_ray.origin + t * mouse_ray.direction;
+
+                StampMode stamp_mode =
+                    (is_lmb_dragging) ? StampMode::PLACE : StampMode::DELETE;
+                // add/remove voxels
+                stamp_brush(stamp_mode, intersection, bundle,
+                            skip_update_buffers);
+            }
+        }
+    }
+}
 
 auto VoxelBrush::stamp_brush(StampMode mode, glm::vec3 position,
                              const EventBundle &bundle,
@@ -188,10 +160,4 @@ auto VoxelBrush::stamp_brush(StampMode mode, glm::vec3 position,
         bundle.scene->set_voxel_empty(this->depth, position,
                                       skip_update_buffers);
     }
-}
-
-auto VoxelBrush::handle_activate(const EventBundle &bundle) -> void {}
-
-auto VoxelBrush::handle_deactivate(const EventBundle &bundle) -> void {
-    this->drag_buttonmask = 0u;
 }

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -39,6 +39,10 @@ auto VoxelBrush::handle_mouse_button_event(const SDL_MouseButtonEvent &event,
     if (mods != SDL_KMOD_NONE)
         return;
 
+    // only care about left and right click
+    if (event.button != SDL_BUTTON_LEFT && event.button != SDL_BUTTON_RIGHT)
+        return;
+
     // confirmed we clicked! track this drag
     this->drag_buttonmask = this->drag_buttonmask | (1u << event.button);
 
@@ -184,4 +188,10 @@ auto VoxelBrush::stamp_brush(StampMode mode, glm::vec3 position,
         bundle.scene->set_voxel_empty(this->depth, position,
                                       skip_update_buffers);
     }
+}
+
+auto VoxelBrush::handle_activate(const EventBundle &bundle) -> void {}
+
+auto VoxelBrush::handle_deactivate(const EventBundle &bundle) -> void {
+    this->drag_buttonmask = 0u;
 }

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -5,7 +5,7 @@
 #include <vxng/geometry.h>
 
 VoxelBrush::VoxelBrush()
-    : current_mode(Mode::AXIS_ALIGNED), size(1), depth(9), flow_density(5.f),
+    : DraggableTool(5.f), current_mode(Mode::AXIS_ALIGNED), size(1), depth(9),
       plane_normal(), brush_kernel(size) {}
 
 VoxelBrush::~VoxelBrush() {}

--- a/editor/src/tools/voxel-brush.cpp
+++ b/editor/src/tools/voxel-brush.cpp
@@ -5,7 +5,7 @@
 
 VoxelBrush::VoxelBrush()
     : current_mode(Mode::AXIS_ALIGNED), size(1), depth(9), flow_density(5.f),
-      plane_normal(), last_mouse_ndc_coords(), abs_brush_kernel() {}
+      plane_normal(), last_mouse_ndc_coords(), brush_kernel(size) {}
 
 VoxelBrush::~VoxelBrush() {}
 
@@ -21,7 +21,7 @@ auto VoxelBrush::render_ui() -> void {
         this->current_mode = Mode::CAMERA_PLANE;
 
     if (ImGui::SliderInt("Size", &this->size, 1, 5))
-        compute_brush_kernel();
+        this->brush_kernel.set_size(this->size);
 
     ImGui::SliderInt("Depth", &this->depth, 0, 9);
     ImGui::SliderFloat("Flow Density", &this->flow_density, 0.f, 20.f);
@@ -124,10 +124,12 @@ auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
                     glm::vec3 intersection =
                         mouse_ray.origin + t * mouse_ray.direction;
 
-                    bool placing = event.state & SDL_BUTTON_LEFT;
+                    StampMode stamp_mode = (event.state & SDL_BUTTON_LEFT)
+                                               ? StampMode::PLACE
+                                               : StampMode::DELETE;
                     // add/remove voxels
-                    stamp_brush(placing ? StampMode::PLACE : StampMode::DELETE,
-                                intersection, bundle, skip_update_buffers);
+                    stamp_brush(stamp_mode, intersection, bundle,
+                                skip_update_buffers);
                 }
             }
         }
@@ -139,57 +141,20 @@ auto VoxelBrush::handle_mouse_motion_event(const SDL_MouseMotionEvent &event,
 auto VoxelBrush::handle_keyboard_event(const SDL_KeyboardEvent &event,
                                        const EventBundle &bundle) -> void {}
 
-auto VoxelBrush::compute_brush_kernel() -> void {
-    this->abs_brush_kernel.clear();
-
-    for (int x = 0; x < this->size; ++x) {
-        for (int y = 0; y < this->size; ++y) {
-            for (int z = 0; z < this->size; ++z) {
-                float magnitude = glm::sqrt(x * x + y * y + z * z);
-                this->abs_brush_kernel[glm::uvec3(x, y, z)] =
-                    magnitude < (this->size - 0.5f);
-            }
-        }
-    }
-}
-
 auto VoxelBrush::stamp_brush(StampMode mode, glm::vec3 position,
                              const EventBundle &bundle,
                              bool skip_update_buffers) -> void {
     float voxel_size =
         bundle.scene->get_chunk_scale() / (float)(1u << this->depth);
 
-    for (int x = 0; x < this->size; ++x) {
-        for (int y = 0; y < this->size; ++y) {
-            for (int z = 0; z < this->size; ++z) {
-                auto kernel_result =
-                    this->abs_brush_kernel.find(glm::uvec3(x, y, z));
-
-                // skip if not found, or if marked as
-                if (kernel_result == this->abs_brush_kernel.end())
-                    continue;
-                if (!kernel_result->second)
-                    continue;
-
-                for (int i = 0; i < 8; ++i) {
-                    glm::vec3 signs = glm::vec3(1u & (i >> 0u), 1u & (i >> 1u),
-                                                1u & (i >> 2u)) *
-                                          2.f -
-                                      1.f;
-
-                    if (mode == StampMode::PLACE) {
-                        bundle.scene->set_voxel_filled(
-                            this->depth,
-                            position + glm::vec3(x, y, z) * signs * voxel_size,
-                            bundle.current_color, true);
-                    } else {
-                        bundle.scene->set_voxel_empty(
-                            this->depth,
-                            position + glm::vec3(x, y, z) * signs * voxel_size,
-                            true);
-                    }
-                }
-            }
+    for (auto &ioffset : this->brush_kernel.get_kernel()) {
+        if (mode == StampMode::PLACE) {
+            bundle.scene->set_voxel_filled(
+                this->depth, position + glm::vec3(ioffset) * voxel_size,
+                bundle.current_color, true);
+        } else {
+            bundle.scene->set_voxel_empty(
+                this->depth, position + glm::vec3(ioffset) * voxel_size, true);
         }
     }
 

--- a/editor/src/tools/voxel-brush.h
+++ b/editor/src/tools/voxel-brush.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "tool.h"
+#include "tools/draggable-tool.h"
 #include "tools/shared/brush-kernel.h"
 
 #include <vxng/geometry.h>
 #include <vxng/scene.h>
 
-class VoxelBrush : public EditorTool {
+class VoxelBrush : public DraggableTool {
   public:
     VoxelBrush();
     ~VoxelBrush();
@@ -21,27 +21,32 @@ class VoxelBrush : public EditorTool {
     auto handle_keyboard_event(const SDL_KeyboardEvent &event,
                                const EventBundle &bundle) -> void override;
 
-    auto handle_activate(const EventBundle &bundle) -> void override;
-    auto handle_deactivate(const EventBundle &bundle) -> void override;
-
+  private:
     typedef enum Mode {
         AXIS_ALIGNED,
         CAMERA_PLANE,
     } Mode;
 
-  private:
+    // params
     Mode current_mode;
     int size;
     int depth;
     float flow_density;
 
-    // for tracking drags
-    uint32_t drag_buttonmask;
+    // locking drags to normals
     vxng::geometry::Ray plane_normal;
-    glm::vec2 last_mouse_ndc_coords;
 
+    // stamping
     BrushKernel brush_kernel;
-    typedef enum StampMode { PLACE, DELETE } StampMode;
+    typedef enum StampMode {
+        PLACE,
+        DELETE,
+    } StampMode;
+
+    auto handle_drag_step(int step_idx, int total_steps,
+                          glm::vec2 step_mouse_ndc_coords,
+                          const EventBundle &bundle) -> void override;
+
     auto stamp_brush(StampMode mode, glm::vec3 position,
                      const EventBundle &bundle,
                      bool skip_update_buffers = false) -> void;

--- a/editor/src/tools/voxel-brush.h
+++ b/editor/src/tools/voxel-brush.h
@@ -21,6 +21,9 @@ class VoxelBrush : public EditorTool {
     auto handle_keyboard_event(const SDL_KeyboardEvent &event,
                                const EventBundle &bundle) -> void override;
 
+    auto handle_activate(const EventBundle &bundle) -> void override;
+    auto handle_deactivate(const EventBundle &bundle) -> void override;
+
     typedef enum Mode {
         AXIS_ALIGNED,
         CAMERA_PLANE,

--- a/editor/src/tools/voxel-brush.h
+++ b/editor/src/tools/voxel-brush.h
@@ -31,7 +31,6 @@ class VoxelBrush : public DraggableTool {
     Mode current_mode;
     int size;
     int depth;
-    float flow_density;
 
     // locking drags to normals
     vxng::geometry::Ray plane_normal;

--- a/editor/src/tools/voxel-brush.h
+++ b/editor/src/tools/voxel-brush.h
@@ -33,6 +33,7 @@ class VoxelBrush : public EditorTool {
     float flow_density;
 
     // for tracking drags
+    uint32_t drag_buttonmask;
     vxng::geometry::Ray plane_normal;
     glm::vec2 last_mouse_ndc_coords;
 

--- a/editor/src/tools/voxel-brush.h
+++ b/editor/src/tools/voxel-brush.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #include "tool.h"
+#include "tools/shared/brush-kernel.h"
 
 #include <vxng/geometry.h>
 #include <vxng/scene.h>
-
-#include <unordered_map>
 
 class VoxelBrush : public EditorTool {
   public:
@@ -37,13 +36,8 @@ class VoxelBrush : public EditorTool {
     vxng::geometry::Ray plane_normal;
     glm::vec2 last_mouse_ndc_coords;
 
-    // for brush sizing
-    std::unordered_map<glm::uvec3, bool> abs_brush_kernel;
-
-    auto compute_brush_kernel() -> void;
-
+    BrushKernel brush_kernel;
     typedef enum StampMode { PLACE, DELETE } StampMode;
-
     auto stamp_brush(StampMode mode, glm::vec3 position,
                      const EventBundle &bundle,
                      bool skip_update_buffers = false) -> void;

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -9,6 +9,7 @@
 #include <webgpu/webgpu_cpp.h>
 
 #include <memory>
+#include <optional>
 #include <unordered_map>
 
 namespace vxng::scene {
@@ -25,6 +26,8 @@ class Scene {
 
     // --------- Queries / Mutation ---------
 
+    auto sample_position(glm::vec3 position) const
+        -> std::optional<glm::u8vec4>;
     auto raycast(const geometry::Ray &ray) const -> geometry::RaycastResult;
 
     auto set_voxel_filled(int depth, glm::vec3 position, glm::u8vec4 color,

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -64,6 +64,36 @@ auto Chunk::get_bounds() const -> geometry::AABB {
     return bounds;
 }
 
+auto Chunk::sample_position(glm::vec3 local_position) const
+    -> std::optional<glm::u8vec4> {
+    const OctreeNode *node = this->root_node.get();
+
+    // create required nodes to specific depth
+    for (int trav_depth = 0; (1u << trav_depth) <= this->resolution;
+         ++trav_depth) {
+        // if solid, just return color
+        if (node->is_leaf)
+            return node->leaf_data.color;
+
+        // dig into specific child node based on position
+        int child_index = ((uint32_t)(local_position.x >= 0) << 0) +
+                          ((uint32_t)(local_position.y >= 0) << 1) +
+                          ((uint32_t)(local_position.z >= 0) << 2);
+
+        // if we're internal, but child doesn't exist, there's nothing there
+        if (!node->children[child_index]) {
+            return {};
+        }
+
+        // put local position into terms of new node bounds
+        local_position = glm::fract((local_position + glm::vec3(0.5f)) * 2.0f) -
+                         glm::vec3(0.5f);
+        node = node->children[child_index].get();
+    }
+
+    return {};
+}
+
 auto Chunk::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
     // If not leaf but no children, return miss
     if (!root_node->is_leaf && !root_node->has_children()) {

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace vxng::scene {
@@ -54,6 +55,8 @@ class Chunk {
 
     // --------- Querying ---------
 
+    auto sample_position(glm::vec3 local_position) const
+        -> std::optional<glm::u8vec4>;
     auto raycast(const geometry::Ray &ray) const -> geometry::RaycastResult;
 
     // --------- Mutation ---------

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -101,6 +101,19 @@ auto Scene::load_vox_file(const std::vector<uint8_t> &buffer) -> void {
     ogt_vox_destroy_scene(scene);
 }
 
+auto Scene::sample_position(glm::vec3 position) const
+    -> std::optional<glm::u8vec4> {
+    auto chunked_info = get_chunked_location_info(position);
+    auto chunk = this->chunks.find(chunked_info.chunk_coord);
+
+    if (chunk == this->chunks.end()) {
+        return {}; // no chunk initialized here, return nothing
+    }
+
+    // chunk exists - sample it!
+    return chunk->second->sample_position(chunked_info.local_position);
+}
+
 auto Scene::raycast(const geometry::Ray &ray) const -> geometry::RaycastResult {
     // scan through chunks for any intersections
     geometry::RaycastResult closest_hit;


### PR DESCRIPTION
This PR will add a paintbrush tool, along with a refactor of the paintbrush tool and some dragging control fixes.

## Changes

- Add "brush kernel" shared class, consumed by voxel brush and paintbrush
- Extract `DraggableTool` abstract class from `VoxelBrush`
- Add `PaintBrush` tool also inheriting from `DraggableTool`
- Add `sample_position` method for `Scene` and `Chunk`
- fix: track tragging accurately, so holding alt for camera movement doesn't screw it up

https://github.com/user-attachments/assets/03f7947d-7b39-48f6-b8ef-0159a53fc698

