### PR TITLE
Add default cube scene template

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -167,7 +167,7 @@ auto Editor::init() -> int {
     this->renderer.set_active_camera(&this->viewport_camera);
 
     this->scene->init_webgpu(this->wgpu.device);
-    this->scene->fill_basic_plane({255, 255, 255, 255});
+    this->scene->fill_center_cubes(7, {255, 255, 255, 255});
     this->renderer.set_scene(this->scene.get());
 
     // initialize imgui
@@ -289,6 +289,10 @@ auto Editor::run_gui() -> void {
                 this->new_empty_scene();
             }
             if (ImGui::BeginMenu("New (Templates)")) {
+                if (ImGui::MenuItem("8x8 Cube")) {
+                    this->new_empty_scene();
+                    this->scene->fill_center_cubes(7, {255, 255, 255, 255});
+                }
                 if (ImGui::MenuItem("Flat Plane")) {
                     this->new_empty_scene();
                     this->scene->fill_basic_plane({255, 255, 255, 255});

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -53,6 +53,7 @@ class Scene {
      * Fills bottom 4 octants of root chunk with the given color.
      */
     auto fill_basic_plane(glm::u8vec4 color) -> void;
+    auto fill_center_cubes(int depth, glm::u8vec4 color) -> void;
 
     auto load_vox_file(const std::vector<uint8_t> &buffer) -> void;
 

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -52,6 +52,20 @@ auto Scene::fill_basic_plane(glm::u8vec4 color) -> void {
     this->set_voxel_filled(1, {delta, -delta, -delta}, color);
 }
 
+auto Scene::fill_center_cubes(int depth, glm::u8vec4 color) -> void {
+    // set 8 center cubes filled
+    float delta = this->chunk_scale / (float)this->chunk_resolution * 0.5f;
+
+    for (int x = -1; x <= 1; x += 2) {
+        for (int y = -1; y <= 1; y += 2) {
+            for (int z = -1; z <= 1; z += 2) {
+                this->set_voxel_filled(depth, glm::vec3(x, y, z) * delta,
+                                       color);
+            }
+        }
+    }
+}
+
 auto Scene::load_vox_file(const std::vector<uint8_t> &buffer) -> void {
     const ogt_vox_scene *scene = ogt_vox_read_scene(&buffer[0], buffer.size());
 


### PR DESCRIPTION
This PR adds an 8x8 cube as the default scene, and as a new template.

<img width="912" height="744" alt="image" src="https://github.com/user-attachments/assets/06faa060-9413-45a6-941c-510bcfaa4398" />
