### PR TITLE
Add airbrush mode for paintbrush

### DIFF
--- a/editor/src/tools/paint-brush.cpp
+++ b/editor/src/tools/paint-brush.cpp
@@ -16,7 +16,7 @@ auto PaintBrush::get_tool_name() -> const char * { return "Paintbrush"; }
 
 // no ui for this yet
 auto PaintBrush::render_ui() -> void {
-    if (ImGui::RadioButton("Full Kernel", (int *)&this->mode,
+    if (ImGui::RadioButton("Normal", (int *)&this->mode,
                            (int)Mode::FULL_KERNEL)) {
     }
     ImGui::SameLine();
@@ -27,9 +27,12 @@ auto PaintBrush::render_ui() -> void {
 
     if (ImGui::SliderInt("Size", &this->size, 1, 10))
         this->brush_kernel.set_size(this->size);
-    if (ImGui::SliderFloat("Airbrush Strength", &this->airbrush_strength,
-                           0.001f, 0.025f))
-        this->brush_kernel.set_size(this->size);
+
+    if (this->mode == Mode::AIRBRUSH) {
+        if (ImGui::SliderFloat("Airbrush Strength", &this->airbrush_strength,
+                               0.001f, 0.025f))
+            this->brush_kernel.set_size(this->size);
+    }
 
     this->render_flow_density_ui();
 }

--- a/editor/src/tools/paint-brush.cpp
+++ b/editor/src/tools/paint-brush.cpp
@@ -16,6 +16,15 @@ auto PaintBrush::get_tool_name() -> const char * { return "Paintbrush"; }
 
 // no ui for this yet
 auto PaintBrush::render_ui() -> void {
+    if (ImGui::RadioButton("Full Kernel", (int *)&this->mode,
+                           (int)Mode::FULL_KERNEL)) {
+    }
+    ImGui::SameLine();
+    if (ImGui::RadioButton("Airbrush", (int *)&this->mode,
+                           (int)Mode::AIRBRUSH)) {
+    }
+    ImGui::Separator();
+
     if (ImGui::SliderInt("Size", &this->size, 1, 10))
         this->brush_kernel.set_size(this->size);
     if (ImGui::SliderFloat("Airbrush Strength", &this->airbrush_strength, 0.01f,
@@ -102,6 +111,11 @@ auto PaintBrush::stamp_paint(glm::vec3 position, const EventBundle &bundle,
     for (auto &ioffset : this->brush_kernel.get_kernel()) {
         glm::vec3 offset_position = position + glm::vec3(ioffset) * voxel_size;
 
+        if (this->mode == Mode::AIRBRUSH) {
+            if (!sample_airbrush_chance(1.f))
+                continue;
+        }
+
         auto sample = bundle.scene->sample_position(offset_position);
         if (sample.has_value() && sample.value() != bundle.current_color)
             bundle.scene->set_voxel_filled(max_depth, offset_position,
@@ -109,6 +123,28 @@ auto PaintBrush::stamp_paint(glm::vec3 position, const EventBundle &bundle,
     }
 
     // set last guy
-    bundle.scene->set_voxel_filled(max_depth, position, bundle.current_color,
-                                   skip_update_buffers);
+
+    switch (this->mode) {
+    case Mode::AIRBRUSH: {
+        if (sample_airbrush_chance(1.f))
+            bundle.scene->set_voxel_filled(max_depth, position,
+                                           bundle.current_color, true);
+        if (!skip_update_buffers) {
+            // ensure we always update buffers if requested
+            bundle.scene->force_update_chunk_buffers(position);
+        }
+        break;
+    }
+    case Mode::FULL_KERNEL: {
+        bundle.scene->set_voxel_filled(
+            max_depth, position, bundle.current_color, skip_update_buffers);
+        break;
+    }
+    }
+}
+
+auto PaintBrush::sample_airbrush_chance(float factor) -> bool {
+    // random value from 0 to 1
+    float rand = this->rdist(this->rgen);
+    return rand < this->airbrush_strength * factor;
 }

--- a/editor/src/tools/paint-brush.cpp
+++ b/editor/src/tools/paint-brush.cpp
@@ -5,7 +5,10 @@
 
 #include <cmath>
 
-PaintBrush::PaintBrush() : DraggableTool(5.f), size(2), brush_kernel(size) {}
+PaintBrush::PaintBrush()
+    : DraggableTool(5.f), mode(Mode::FULL_KERNEL), size(2),
+      airbrush_strength(0.5), brush_kernel(size), rd(), rgen(rd()),
+      rdist(0.f, 1.f) {}
 
 PaintBrush::~PaintBrush() {}
 
@@ -14,6 +17,9 @@ auto PaintBrush::get_tool_name() -> const char * { return "Paintbrush"; }
 // no ui for this yet
 auto PaintBrush::render_ui() -> void {
     if (ImGui::SliderInt("Size", &this->size, 1, 10))
+        this->brush_kernel.set_size(this->size);
+    if (ImGui::SliderFloat("Airbrush Strength", &this->airbrush_strength, 0.01f,
+                           1.f))
         this->brush_kernel.set_size(this->size);
 
     this->render_flow_density_ui();

--- a/editor/src/tools/paint-brush.cpp
+++ b/editor/src/tools/paint-brush.cpp
@@ -7,7 +7,7 @@
 
 PaintBrush::PaintBrush()
     : DraggableTool(5.f), mode(Mode::FULL_KERNEL), size(2),
-      airbrush_strength(0.5), brush_kernel(size), rd(), rgen(rd()),
+      airbrush_strength(0.025f), brush_kernel(size), rd(), rgen(rd()),
       rdist(0.f, 1.f) {}
 
 PaintBrush::~PaintBrush() {}
@@ -27,8 +27,8 @@ auto PaintBrush::render_ui() -> void {
 
     if (ImGui::SliderInt("Size", &this->size, 1, 10))
         this->brush_kernel.set_size(this->size);
-    if (ImGui::SliderFloat("Airbrush Strength", &this->airbrush_strength, 0.01f,
-                           1.f))
+    if (ImGui::SliderFloat("Airbrush Strength", &this->airbrush_strength,
+                           0.001f, 0.025f))
         this->brush_kernel.set_size(this->size);
 
     this->render_flow_density_ui();

--- a/editor/src/tools/paint-brush.h
+++ b/editor/src/tools/paint-brush.h
@@ -46,4 +46,6 @@ class PaintBrush : public DraggableTool {
 
     auto stamp_paint(glm::vec3 position, const EventBundle &bundle,
                      bool skip_update_buffers = false) -> void;
+
+    auto sample_airbrush_chance(float factor) -> bool;
 };

--- a/editor/src/tools/paint-brush.h
+++ b/editor/src/tools/paint-brush.h
@@ -6,6 +6,8 @@
 #include <vxng/geometry.h>
 #include <vxng/scene.h>
 
+#include <random>
+
 class PaintBrush : public DraggableTool {
   public:
     PaintBrush();
@@ -22,11 +24,21 @@ class PaintBrush : public DraggableTool {
                                const EventBundle &bundle) -> void override;
 
   private:
-    // params
-    int size;
+    typedef enum Mode {
+        FULL_KERNEL,
+        AIRBRUSH,
+    } Mode;
 
-    // stamping
+    // params
+    Mode mode;
+    int size;
+    float airbrush_strength;
+
+    // stamping / airbrushing
     BrushKernel brush_kernel;
+    std::random_device rd;
+    std::mt19937 rgen;
+    std::uniform_real_distribution<float> rdist;
 
     auto handle_drag_step(int step_idx, int total_steps,
                           glm::vec2 step_mouse_ndc_coords,

--- a/libs/vxng/include/vxng/scene.h
+++ b/libs/vxng/include/vxng/scene.h
@@ -34,6 +34,7 @@ class Scene {
                           bool skip_update_buffers = false) -> void;
     auto set_voxel_empty(int depth, glm::vec3 position,
                          bool skip_update_buffers = false) -> void;
+    auto force_update_chunk_buffers(glm::vec3 position) -> void;
 
     // --------- Utility ---------
 

--- a/libs/vxng/src/scene/chunk.cpp
+++ b/libs/vxng/src/scene/chunk.cpp
@@ -224,6 +224,8 @@ auto Chunk::reposition(glm::vec3 pos, float scale) -> void {
     update_buffers();
 }
 
+auto Chunk::force_update_buffers() -> void { update_buffers(); }
+
 auto Chunk::set_voxel_grid_data(const uint8_t *data, glm::ivec3 size,
                                 const std::array<glm::u8vec4, 256> &palette,
                                 glm::ivec3 offset) -> void {

--- a/libs/vxng/src/scene/chunk.h
+++ b/libs/vxng/src/scene/chunk.h
@@ -76,6 +76,7 @@ class Chunk {
 
     /** Sets new position and scale, then updates buffers */
     auto reposition(glm::vec3 pos, float scale) -> void;
+    auto force_update_buffers() -> void;
 
     // --------- Rendering ---------
 

--- a/libs/vxng/src/scene/scene.cpp
+++ b/libs/vxng/src/scene/scene.cpp
@@ -167,6 +167,16 @@ auto Scene::set_voxel_empty(int depth, glm::vec3 position,
                                   skip_update_buffers);
 }
 
+auto Scene::force_update_chunk_buffers(glm::vec3 position) -> void {
+    auto chunked_location = get_chunked_location_info(position);
+    auto &target_chunk = chunks.at(chunked_location.chunk_coord);
+
+    if (!target_chunk)
+        return;
+
+    target_chunk->force_update_buffers();
+}
+
 auto Scene::get_chunk_scale() const -> float { return this->chunk_scale; }
 
 auto Scene::get_chunk_resolution() const -> int {


### PR DESCRIPTION
This PR adds an "airbrush" mode for the paintbrush tool.

It randomly chooses whether or not to actually paint in voxels.

## Changes

- Add "airbrush" mode for paintbrush, with a tweakable "airbrush strength"
- Add `force_update_chunk_buffers` helpers to scene and chunk 

https://github.com/user-attachments/assets/68419971-6454-4a92-bf10-9b7c1554c817



