### PR TITLE
Add scene lighting options

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -20,6 +20,7 @@ Editor::Editor()
       scene(std::make_unique<vxng::scene::Scene>(SCENE_RESOLUTION,
                                                  DEFAULT_SCENE_SCALE)),
       cursors(), tools(), current_tool(&tools.voxel_brush), palette(),
+      light_dir(0.5, 1.0, 0.3), dirlight_color(0.8), ambient_light_color(0.2),
       background_color(0.1) {
     palette.init_default_colors();
 };
@@ -163,10 +164,10 @@ auto Editor::init() -> int {
     // set initial renderer size (shader globals)
     this->renderer.resize(width, height);
     // set renderer light params
-    this->renderer.set_light_dir(glm::vec3(0.5, 1.0, 0.3));
-    this->renderer.set_dirlight_color(glm::vec3(0.8));
-    this->renderer.set_ambient_color(glm::vec3(0.2));
-    this->renderer.set_background_color(background_color);
+    this->renderer.set_light_dir(this->light_dir);
+    this->renderer.set_dirlight_color(this->dirlight_color);
+    this->renderer.set_ambient_color(this->ambient_light_color);
+    this->renderer.set_background_color(this->background_color);
 
     this->viewport_camera.init_webgpu(this->wgpu.device);
     this->viewport_camera.set_aspect_ratio(static_cast<float>(width) / height);

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -331,7 +331,32 @@ auto Editor::run_gui() -> void {
         ImGui::Begin("Options");
         if (ImGui::CollapsingHeader("Scene", ImGuiTreeNodeFlags_DefaultOpen)) {
 
+            // Light settings
+            ImGui::SeparatorText("Lighting");
+
+            ImGui::Text("Ambient Light Color");
+            if (ImGui::ColorEdit3("##AmbientLightColor",
+                                  &this->ambient_light_color[0])) {
+                this->renderer.set_ambient_color(this->ambient_light_color);
+            };
+
+            ImGui::Text("Directional Light Color");
+            if (ImGui::ColorEdit3("##DirectionalLightColor",
+                                  &this->dirlight_color[0])) {
+                this->renderer.set_dirlight_color(this->dirlight_color);
+            };
+
+            ImGui::Text("Light Direction");
+            if (ImGui::SliderFloat3("##DirectionalLightDirection",
+                                    &this->light_dir[0], -1.0f, 1.0f)) {
+                this->renderer.set_light_dir(this->light_dir);
+            };
+
+            ImGui::Dummy(ImVec2(0.0f, 16.0f));
+
             // Scene Resolution
+            ImGui::SeparatorText("Scale");
+
             float scale = this->scene->get_chunk_scale();
             int unit_voxel_depth = glm::log2(512.f / scale);
             int original_uvd = unit_voxel_depth;

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -19,7 +19,8 @@ Editor::Editor()
     : renderer(), viewport_camera(),
       scene(std::make_unique<vxng::scene::Scene>(SCENE_RESOLUTION,
                                                  DEFAULT_SCENE_SCALE)),
-      cursors(), tools(), current_tool(&tools.voxel_brush), palette() {
+      cursors(), tools(), current_tool(&tools.voxel_brush), palette(),
+      background_color(0.1) {
     palette.init_default_colors();
 };
 
@@ -165,6 +166,7 @@ auto Editor::init() -> int {
     this->renderer.set_light_dir(glm::vec3(0.5, 1.0, 0.3));
     this->renderer.set_dirlight_color(glm::vec3(0.8));
     this->renderer.set_ambient_color(glm::vec3(0.2));
+    this->renderer.set_background_color(background_color);
 
     this->viewport_camera.init_webgpu(this->wgpu.device);
     this->viewport_camera.set_aspect_ratio(static_cast<float>(width) / height);
@@ -239,7 +241,8 @@ auto Editor::draw_to_surface() -> void {
     renderPassColorAttachment.resolveTarget = nullptr;
     renderPassColorAttachment.loadOp = wgpu::LoadOp::Clear;
     renderPassColorAttachment.storeOp = wgpu::StoreOp::Store;
-    renderPassColorAttachment.clearValue = wgpu::Color{0.0, 0.0, 0.0, 1.0};
+    renderPassColorAttachment.clearValue = wgpu::Color{
+        background_color.r, background_color.g, background_color.b, 1.0};
 
     // depth attachment for multi-chunk rendering
     wgpu::RenderPassDepthStencilAttachment depthAttachment;

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -352,6 +352,12 @@ auto Editor::run_gui() -> void {
                 this->renderer.set_light_dir(this->light_dir);
             };
 
+            ImGui::Text("Background Color");
+            if (ImGui::ColorEdit3("##BackgroundColor",
+                                  &this->background_color[0])) {
+                this->renderer.set_background_color(this->background_color);
+            };
+
             ImGui::Dummy(ImVec2(0.0f, 16.0f));
 
             // Scene Resolution

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -161,6 +161,10 @@ auto Editor::init() -> int {
 
     // set initial renderer size (shader globals)
     this->renderer.resize(width, height);
+    // set renderer light params
+    this->renderer.set_light_dir(glm::vec3(0.5, 1.0, 0.3));
+    this->renderer.set_dirlight_color(glm::vec3(0.8));
+    this->renderer.set_ambient_color(glm::vec3(0.2));
 
     this->viewport_camera.init_webgpu(this->wgpu.device);
     this->viewport_camera.set_aspect_ratio(static_cast<float>(width) / height);

--- a/editor/src/editor.h
+++ b/editor/src/editor.h
@@ -69,6 +69,9 @@ class Editor {
         bool show_options = true;
     } panels;
 
+    glm::vec3 light_dir;
+    glm::vec3 dirlight_color;
+    glm::vec3 ambient_light_color;
     glm::vec3 background_color;
 
     // menu options

--- a/editor/src/editor.h
+++ b/editor/src/editor.h
@@ -69,6 +69,8 @@ class Editor {
         bool show_options = true;
     } panels;
 
+    glm::vec3 background_color;
+
     // menu options
     auto new_empty_scene() -> void;
 

--- a/libs/vxng/include/vxng/renderer.h
+++ b/libs/vxng/include/vxng/renderer.h
@@ -19,6 +19,9 @@ class Renderer {
     auto init_webgpu(wgpu::Device device) -> bool;
     auto get_depth_texture_view() const -> wgpu::TextureView;
     auto resize(int width, int height) -> void;
+    auto set_light_dir(glm::vec3 light_dir) -> void;
+    auto set_dirlight_color(glm::vec3 color) -> void;
+    auto set_ambient_color(glm::vec3 color) -> void;
     auto set_scene(vxng::scene::Scene const *scene) -> void;
     auto set_active_camera(const vxng::camera::Camera *camera) -> void;
     auto render(wgpu::RenderPassEncoder &render_pass) const -> void;

--- a/libs/vxng/include/vxng/renderer.h
+++ b/libs/vxng/include/vxng/renderer.h
@@ -22,6 +22,7 @@ class Renderer {
     auto set_light_dir(glm::vec3 light_dir) -> void;
     auto set_dirlight_color(glm::vec3 color) -> void;
     auto set_ambient_color(glm::vec3 color) -> void;
+    auto set_background_color(glm::vec3 color) -> void;
     auto set_scene(vxng::scene::Scene const *scene) -> void;
     auto set_active_camera(const vxng::camera::Camera *camera) -> void;
     auto render(wgpu::RenderPassEncoder &render_pass) const -> void;
@@ -47,6 +48,8 @@ class Renderer {
 
     const vxng::camera::Camera *active_camera;
     const vxng::scene::Scene *active_scene;
+
+    glm::vec3 background_color;
 };
 
 } // namespace vxng

--- a/libs/vxng/src/renderer.cpp
+++ b/libs/vxng/src/renderer.cpp
@@ -34,7 +34,7 @@ auto Renderer::init_webgpu(wgpu::Device device) -> bool {
     {
         wgpu::BufferDescriptor globals_desc;
         globals_desc.label = "Scene globals uniform buffer";
-        globals_desc.size = 4;
+        globals_desc.size = 64;
         globals_desc.usage =
             wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
         globals_buffer = device.CreateBuffer(&globals_desc);
@@ -52,7 +52,7 @@ auto Renderer::init_webgpu(wgpu::Device device) -> bool {
         globals_layout_entry.visibility =
             wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
         globals_layout_entry.buffer.type = wgpu::BufferBindingType::Uniform;
-        globals_layout_entry.buffer.minBindingSize = 4;
+        globals_layout_entry.buffer.minBindingSize = 64;
 
         wgpu::BindGroupLayoutDescriptor globals_bgl_desc;
         globals_bgl_desc.label = "Globals bind group layout";
@@ -85,7 +85,7 @@ auto Renderer::init_webgpu(wgpu::Device device) -> bool {
         globals_entry.binding = 0;
         globals_entry.buffer = globals_buffer;
         globals_entry.offset = 0;
-        globals_entry.size = 4;
+        globals_entry.size = 64;
 
         wgpu::BindGroupDescriptor bg_desc;
         bg_desc.layout = globals_bind_group_layout;
@@ -212,6 +212,21 @@ auto Renderer::resize(int width, int height) -> void {
 
     create_depth_texture(width, height);
 };
+
+auto Renderer::set_light_dir(glm::vec3 dir) -> void {
+    this->wgpu.queue.WriteBuffer(this->wgpu.globals_uniforms_buffer, 16, &dir,
+                                 sizeof(float) * 3);
+}
+
+auto Renderer::set_dirlight_color(glm::vec3 color) -> void {
+    this->wgpu.queue.WriteBuffer(this->wgpu.globals_uniforms_buffer, 32, &color,
+                                 sizeof(float) * 3);
+}
+
+auto Renderer::set_ambient_color(glm::vec3 color) -> void {
+    this->wgpu.queue.WriteBuffer(this->wgpu.globals_uniforms_buffer, 48, &color,
+                                 sizeof(float) * 3);
+}
 
 auto Renderer::set_scene(const vxng::scene::Scene *scene) -> void {
     this->active_scene = scene;

--- a/libs/vxng/src/renderer.cpp
+++ b/libs/vxng/src/renderer.cpp
@@ -11,7 +11,7 @@
 
 namespace vxng {
 
-Renderer::Renderer() {};
+Renderer::Renderer() : background_color(0.3) {};
 Renderer::~Renderer() {
     // WebGPU objects are automatically released when their reference counted
     // handles all go out of scope
@@ -226,6 +226,10 @@ auto Renderer::set_dirlight_color(glm::vec3 color) -> void {
 auto Renderer::set_ambient_color(glm::vec3 color) -> void {
     this->wgpu.queue.WriteBuffer(this->wgpu.globals_uniforms_buffer, 48, &color,
                                  sizeof(float) * 3);
+}
+
+auto Renderer::set_background_color(glm::vec3 color) -> void {
+    this->background_color = color;
 }
 
 auto Renderer::set_scene(const vxng::scene::Scene *scene) -> void {

--- a/libs/vxng/src/wgsl/chunk.wgsl.cpp
+++ b/libs/vxng/src/wgsl/chunk.wgsl.cpp
@@ -6,6 +6,9 @@ const std::string CHUNK_WGSL = R"wgsl(
 // Uniform buffer for global settings
 struct Globals {
     aspectRatio: f32,
+    lightDir: vec3<f32>,
+    directionalLight: vec3<f32>,
+    ambientLight: vec3<f32>,
 }
 
 // Uniform buffer for camera settings
@@ -378,10 +381,9 @@ fn fs_main(input: VertexOutput) -> FragmentOutput {
         discard;
     } else {
         // simple half lambert lighting
-        let lightDir = normalize(vec3<f32>(0.5, 1.0, 0.3));
-        let ambient = 0.2;
-        let diffuse = max(dot(result.normal, lightDir) * 0.5 + 0.5, 0.0);
-        let lighting = ambient + (1.0 - ambient) * diffuse;
+        let lightDir = normalize(globals.lightDir);
+        let diffuse = max(dot(result.normal, lightDir) * 0.5 + 0.5, 0.0) * globals.directionalLight;
+        let lighting = globals.ambientLight + diffuse;
 
         output.color = vec4<f32>(result.color.rgb * lighting, result.color.a);
         output.depth = computeDepth(viewRay, result.t);


### PR DESCRIPTION
This PR adds options for directional + ambient light, as well as background color.

## Changes

- Add controls for dirlight direction + color, and ambient light
- Add background color controls
- Update globals buffer with lighting params, consume in shader

<img width="912" height="744" alt="image" src="https://github.com/user-attachments/assets/4b0888f8-7ae3-48a4-9d91-97c135616518" />

